### PR TITLE
Add status and prompt customization hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,8 +132,8 @@ The main config knobs are:
 - `KeyGroup`: `LessKeyGroup` or `EmptyKeyGroup`
 - `UnbindKeys` and `KeyBindings`: remove or prepend bindings in normal, help,
   or prompt contexts
-- `Chrome`: optional frame/title styling
-- `Text`: override help text, status text, and UI strings
+- `Chrome`: optional frame/title styling plus status/prompt style slots
+- `Text`: override help text, status text, prompt text, and UI strings
 
 By default, literal search uses smart-case behavior:
 
@@ -158,6 +158,14 @@ Embedders are not locked to the bundled keys. They can:
 
 `SearchState` exposes the current committed or preview search query, direction,
 mode, case handling, match count/current position, and any regex compile error.
+
+For host chrome integration:
+
+- `Text.StatusLine` can replace the full left/right status bar text using
+  `StatusInfo`
+- `Text.PromptLine` can replace the full built-in prompt text using `PromptInfo`
+- `Chrome.StatusStyle`, `Chrome.PromptStyle`, and `Chrome.PromptErrorStyle`
+  can restyle the built-in bottom bar without replacing pager rendering
 
 ## Render Modes
 

--- a/chrome.go
+++ b/chrome.go
@@ -32,6 +32,12 @@ type Chrome struct {
 	BorderStyle tcell.Style
 	// TitleStyle controls the style used when drawing the frame title.
 	TitleStyle tcell.Style
+	// StatusStyle controls the style used when drawing the status bar.
+	StatusStyle tcell.Style
+	// PromptStyle controls the style used when drawing the prompt line.
+	PromptStyle tcell.Style
+	// PromptErrorStyle controls the style used for prompt-side error text.
+	PromptErrorStyle tcell.Style
 }
 
 // SingleFrame returns a single-line box drawing frame.

--- a/internal/view/chrome.go
+++ b/internal/view/chrome.go
@@ -25,10 +25,13 @@ func (f Frame) enabled() bool {
 
 // Chrome configures optional decorative chrome around the viewer body.
 type Chrome struct {
-	Title       string
-	Frame       Frame
-	BorderStyle tcell.Style
-	TitleStyle  tcell.Style
+	Title            string
+	Frame            Frame
+	BorderStyle      tcell.Style
+	TitleStyle       tcell.Style
+	StatusStyle      tcell.Style
+	PromptStyle      tcell.Style
+	PromptErrorStyle tcell.Style
 }
 
 func (c Chrome) withDefaults() Chrome {
@@ -37,6 +40,15 @@ func (c Chrome) withDefaults() Chrome {
 	}
 	if c.TitleStyle == tcell.StyleDefault {
 		c.TitleStyle = tcell.StyleDefault.Foreground(tcolor.PaletteColor(15)).Bold(true)
+	}
+	if c.StatusStyle == tcell.StyleDefault {
+		c.StatusStyle = statusBarStyle
+	}
+	if c.PromptStyle == tcell.StyleDefault {
+		c.PromptStyle = tcell.StyleDefault.Reverse(true)
+	}
+	if c.PromptErrorStyle == tcell.StyleDefault {
+		c.PromptErrorStyle = c.PromptStyle.Foreground(tcolor.Red)
 	}
 	return c
 }

--- a/internal/view/text.go
+++ b/internal/view/text.go
@@ -20,6 +20,7 @@ type Text struct {
 	StatusSearchInfo func(query string, current, total int) string
 	StatusPosition   func(current, total, column int) string
 	FollowMode       string
+	StatusLine       func(StatusInfo) (left, right string)
 
 	SearchEmpty      string
 	SearchNotFound   func(query string) string
@@ -33,6 +34,7 @@ type Text struct {
 
 	LeftOverflowIndicator  string
 	RightOverflowIndicator string
+	PromptLine             func(PromptInfo) string
 }
 
 func (t Text) helpLines() []string {

--- a/internal/view/ui.go
+++ b/internal/view/ui.go
@@ -1,0 +1,33 @@
+// Copyright 2026 Garrett D'Amore
+// SPDX-License-Identifier: Apache-2.0
+
+package view
+
+// StatusInfo summarizes the built-in status bar state passed to Text.StatusLine.
+type StatusInfo struct {
+	Search       SearchSnapshot
+	Following    bool
+	Message      string
+	Position     Position
+	DefaultLeft  string
+	DefaultRight string
+}
+
+// PromptKind identifies the active built-in prompt type.
+type PromptKind int
+
+const (
+	PromptKindSearchForward PromptKind = iota
+	PromptKindSearchBackward
+	PromptKindCommand
+)
+
+// PromptInfo summarizes the built-in prompt state passed to Text.PromptLine.
+type PromptInfo struct {
+	Kind        PromptKind
+	Prefix      string
+	Input       string
+	Error       string
+	Search      SearchSnapshot
+	DefaultText string
+}

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -588,7 +588,7 @@ func (v *Viewer) drawFrame(screen tcell.Screen, title string) {
 }
 
 func (v *Viewer) drawStatus(screen tcell.Screen, y int) {
-	style := statusBarStyle
+	style := v.cfg.Chrome.StatusStyle
 	screen.PutStrStyled(0, y, strings.Repeat(" ", max(v.width, 0)), style)
 
 	leftOverflow, rightOverflow := v.statusOverflow()
@@ -720,6 +720,20 @@ func (v *Viewer) statusText() (left, right string) {
 		current = min(v.rowOffset+1, len(v.layout.Rows))
 	}
 	right = v.text.StatusPosition(current, len(v.layout.Rows), v.colOffset)
+	if v.text.StatusLine != nil {
+		return v.text.StatusLine(StatusInfo{
+			Search:    v.SearchSnapshot(),
+			Following: v.follow,
+			Message:   v.message,
+			Position: Position{
+				Row:    current,
+				Rows:   len(v.layout.Rows),
+				Column: v.colOffset,
+			},
+			DefaultLeft:  left,
+			DefaultRight: right,
+		})
+	}
 	return left, right
 }
 
@@ -732,10 +746,10 @@ func (v *Viewer) statusOverflow() (left, right bool) {
 }
 
 func (v *Viewer) drawPrompt(screen tcell.Screen, y int) {
-	style := tcell.StyleDefault.Reverse(true)
+	style := v.cfg.Chrome.PromptStyle
 	prompt := ""
 	if v.prompt != nil {
-		prompt = " " + v.prompt.String()
+		prompt = " " + v.promptText()
 	}
 	screen.PutStrStyled(0, y, padRightToWidth(prompt, v.width), style)
 	if v.prompt != nil && v.prompt.errText != "" && v.width > 0 {
@@ -743,9 +757,37 @@ func (v *Viewer) drawPrompt(screen tcell.Screen, y int) {
 		paddedPrompt := truncateToWidth(prompt, v.width)
 		start := stringWidth(paddedPrompt)
 		if start < v.width {
-			errStyle := style.Foreground(tcolor.Red)
-			screen.PutStrStyled(start, y, truncateToWidth(errText, v.width-start), errStyle)
+			screen.PutStrStyled(start, y, truncateToWidth(errText, v.width-start), v.cfg.Chrome.PromptErrorStyle)
 		}
+	}
+}
+
+func (v *Viewer) promptText() string {
+	if v.prompt == nil {
+		return ""
+	}
+	defaultText := v.prompt.String()
+	if v.text.PromptLine == nil {
+		return defaultText
+	}
+	return v.text.PromptLine(PromptInfo{
+		Kind:        toPromptKind(v.prompt.kind),
+		Prefix:      v.prompt.prefix,
+		Input:       string(v.prompt.buffer),
+		Error:       v.prompt.errText,
+		Search:      v.SearchSnapshot(),
+		DefaultText: defaultText,
+	})
+}
+
+func toPromptKind(kind promptKind) PromptKind {
+	switch kind {
+	case promptSearchBackward:
+		return PromptKindSearchBackward
+	case promptCommand:
+		return PromptKindCommand
+	default:
+		return PromptKindSearchForward
 	}
 }
 

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -1156,6 +1156,126 @@ func TestStatusBarUsesDisplayWidthForRightAlignedText(t *testing.T) {
 	}
 }
 
+func TestStatusLineFormatterOverridesBuiltInStatusText(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alpha\nbeta\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{
+		TabWidth:   4,
+		WrapMode:   layout.NoWrap,
+		ShowStatus: true,
+		Text: Text{
+			StatusLine: func(info StatusInfo) (left, right string) {
+				if info.DefaultLeft == "" || info.DefaultRight == "" {
+					t.Fatalf("StatusLine got empty defaults: %+v", info)
+				}
+				return "L:" + info.DefaultLeft, "R:" + info.DefaultRight
+			},
+		},
+	})
+	v.SetSize(20, 2)
+	v.relayout()
+
+	leftText, rightText := v.statusText()
+	if got, want := leftText, "L:search:smart,sub"; got != want {
+		t.Fatalf("left status text = %q, want %q", got, want)
+	}
+	if !strings.HasPrefix(rightText, "R:row 1/2  col 0") {
+		t.Fatalf("right status text = %q, want prefix %q", rightText, "R:row 1/2  col 0")
+	}
+}
+
+func TestPromptLineFormatterOverridesBuiltInPromptText(t *testing.T) {
+	doc := model.NewDocument(4)
+	v := New(doc, Config{
+		TabWidth: 4,
+		WrapMode: layout.NoWrap,
+		Text: Text{
+			PromptLine: func(info PromptInfo) string {
+				if got, want := info.DefaultText, "/[smart,sub] a"; got != want {
+					t.Fatalf("PromptLine default text = %q, want %q", got, want)
+				}
+				if got, want := info.Kind, PromptKindSearchForward; got != want {
+					t.Fatalf("PromptLine kind = %v, want %v", got, want)
+				}
+				return "find>" + info.Input
+			},
+		},
+	})
+	v.SetSize(20, 2)
+	v.beginPrompt(promptSearchForward)
+	v.prompt.buffer = []rune("a")
+
+	if got, want := v.promptText(), "find>a"; got != want {
+		t.Fatalf("promptText() = %q, want %q", got, want)
+	}
+}
+
+func TestDrawStatusAndPromptUseConfiguredStyles(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alpha\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	statusStyle := tcell.StyleDefault.Foreground(tcolor.PaletteColor(3)).Background(tcolor.PaletteColor(7))
+	promptStyle := tcell.StyleDefault.Foreground(tcolor.PaletteColor(2)).Background(tcolor.PaletteColor(0)).Bold(true)
+	promptErrorStyle := tcell.StyleDefault.Foreground(tcolor.PaletteColor(1)).Background(tcolor.PaletteColor(0))
+
+	v := New(doc, Config{
+		TabWidth:   4,
+		WrapMode:   layout.NoWrap,
+		ShowStatus: true,
+		SearchMode: SearchRegex,
+		Chrome: Chrome{
+			StatusStyle:      statusStyle,
+			PromptStyle:      promptStyle,
+			PromptErrorStyle: promptErrorStyle,
+		},
+	})
+	v.SetSize(20, 2)
+	v.relayout()
+
+	_, screen := newMockScreen(t, 20, 2)
+	defer screen.Fini()
+
+	v.drawStatus(screen, 1)
+	_, gotStatusStyle, _ := screen.Get(0, 1)
+	if got, want := gotStatusStyle.GetForeground(), statusStyle.GetForeground(); got != want {
+		t.Fatalf("status fg = %v, want %v", got, want)
+	}
+	if got, want := gotStatusStyle.GetBackground(), statusStyle.GetBackground(); got != want {
+		t.Fatalf("status bg = %v, want %v", got, want)
+	}
+
+	v.beginPrompt(promptSearchForward)
+	v.prompt.buffer = []rune("(")
+	v.updatePromptPreview()
+	screen.Clear()
+	v.drawPrompt(screen, 1)
+
+	_, gotPromptStyle, _ := screen.Get(1, 1)
+	if got, want := gotPromptStyle.GetForeground(), promptStyle.GetForeground(); got != want {
+		t.Fatalf("prompt fg = %v, want %v", got, want)
+	}
+	if got, want := gotPromptStyle.GetBackground(), promptStyle.GetBackground(); got != want {
+		t.Fatalf("prompt bg = %v, want %v", got, want)
+	}
+	if !gotPromptStyle.HasBold() {
+		t.Fatal("prompt style lost bold attribute")
+	}
+
+	errorStart := stringWidth(truncateToWidth(" "+v.promptText(), v.width))
+	_, gotErrorStyle, _ := screen.Get(errorStart, 1)
+	if got, want := gotErrorStyle.GetForeground(), promptErrorStyle.GetForeground(); got != want {
+		t.Fatalf("prompt error fg = %v, want %v", got, want)
+	}
+	if got, want := gotErrorStyle.GetBackground(), promptErrorStyle.GetBackground(); got != want {
+		t.Fatalf("prompt error bg = %v, want %v", got, want)
+	}
+}
+
 func TestTruncateToWidthUsesDisplayCellsAndPreservesUTF8(t *testing.T) {
 	got := truncateToWidth("é界b", 2)
 	if !utf8.ValidString(got) {

--- a/pager.go
+++ b/pager.go
@@ -527,12 +527,25 @@ func toInternalText(text Text) iview.Text {
 	}
 
 	return iview.Text{
-		HelpTitle:              text.HelpTitle,
-		HelpClose:              text.HelpClose,
-		HelpBody:               text.HelpBody,
-		StatusSearchInfo:       text.StatusSearchInfo,
-		StatusPosition:         text.StatusPosition,
-		FollowMode:             text.FollowMode,
+		HelpTitle:        text.HelpTitle,
+		HelpClose:        text.HelpClose,
+		HelpBody:         text.HelpBody,
+		StatusSearchInfo: text.StatusSearchInfo,
+		StatusPosition:   text.StatusPosition,
+		FollowMode:       text.FollowMode,
+		StatusLine: func(info iview.StatusInfo) (left, right string) {
+			if text.StatusLine == nil {
+				return info.DefaultLeft, info.DefaultRight
+			}
+			return text.StatusLine(StatusInfo{
+				Search:       toPublicSearchState(info.Search),
+				Following:    info.Following,
+				Message:      info.Message,
+				Position:     Position{Row: info.Position.Row, Rows: info.Position.Rows, Column: info.Position.Column},
+				DefaultLeft:  info.DefaultLeft,
+				DefaultRight: info.DefaultRight,
+			})
+		},
 		SearchEmpty:            text.SearchEmpty,
 		SearchNotFound:         text.SearchNotFound,
 		SearchMatchCount:       text.SearchMatchCount,
@@ -543,14 +556,30 @@ func toInternalText(text Text) iview.Text {
 		CommandLine:            text.CommandLine,
 		LeftOverflowIndicator:  text.LeftOverflowIndicator,
 		RightOverflowIndicator: text.RightOverflowIndicator,
+		PromptLine: func(info iview.PromptInfo) string {
+			if text.PromptLine == nil {
+				return info.DefaultText
+			}
+			return text.PromptLine(PromptInfo{
+				Kind:        toPublicPromptKind(info.Kind),
+				Prefix:      info.Prefix,
+				Input:       info.Input,
+				Error:       info.Error,
+				Search:      toPublicSearchState(info.Search),
+				DefaultText: info.DefaultText,
+			})
+		},
 	}
 }
 
 func toInternalChrome(chrome Chrome) iview.Chrome {
 	return iview.Chrome{
-		Title:       chrome.Title,
-		BorderStyle: chrome.BorderStyle,
-		TitleStyle:  chrome.TitleStyle,
+		Title:            chrome.Title,
+		BorderStyle:      chrome.BorderStyle,
+		TitleStyle:       chrome.TitleStyle,
+		StatusStyle:      chrome.StatusStyle,
+		PromptStyle:      chrome.PromptStyle,
+		PromptErrorStyle: chrome.PromptErrorStyle,
 		Frame: iview.Frame{
 			Horizontal:  chrome.Frame.Horizontal,
 			Vertical:    chrome.Frame.Vertical,
@@ -559,5 +588,29 @@ func toInternalChrome(chrome Chrome) iview.Chrome {
 			BottomLeft:  chrome.Frame.BottomLeft,
 			BottomRight: chrome.Frame.BottomRight,
 		},
+	}
+}
+
+func toPublicSearchState(state iview.SearchSnapshot) SearchState {
+	return SearchState{
+		Query:        state.Query,
+		Forward:      state.Forward,
+		CaseMode:     SearchCaseMode(state.CaseMode),
+		Mode:         SearchMode(state.Mode),
+		MatchCount:   state.MatchCount,
+		CurrentMatch: state.CurrentMatch,
+		CompileError: state.CompileError,
+		Preview:      state.Preview,
+	}
+}
+
+func toPublicPromptKind(kind iview.PromptKind) PromptKind {
+	switch kind {
+	case iview.PromptKindSearchBackward:
+		return PromptSearchBackward
+	case iview.PromptKindCommand:
+		return PromptCommand
+	default:
+		return PromptSearchForward
 	}
 }

--- a/pager_test.go
+++ b/pager_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gdamore/tcell/v3"
+	"github.com/gdamore/tcell/v3/vt"
 )
 
 func TestPagerAppendAndLen(t *testing.T) {
@@ -536,6 +537,63 @@ func TestPagerSearchStateShowsInvalidRegexPreview(t *testing.T) {
 	}
 }
 
+func TestPagerTextHooksFormatStatusAndPrompt(t *testing.T) {
+	statusCalled := false
+	promptCalled := false
+	pager := New(Config{
+		TabWidth:   4,
+		WrapMode:   NoWrap,
+		ShowStatus: true,
+		Text: Text{
+			StatusLine: func(info StatusInfo) (left, right string) {
+				statusCalled = true
+				if got, want := info.Position.Row, 1; got != want {
+					t.Fatalf("StatusLine position row = %d, want %d", got, want)
+				}
+				return "LEFT", "RIGHT"
+			},
+			PromptLine: func(info PromptInfo) string {
+				promptCalled = true
+				if got, want := info.Kind, PromptSearchForward; got != want {
+					t.Fatalf("PromptLine kind = %v, want %v", got, want)
+				}
+				return "find>" + info.Input
+			},
+		},
+	})
+	pager.SetSize(20, 2)
+	if err := pager.AppendString("alpha\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	screen := newPagerMockScreen(t, 20, 2)
+	defer screen.Fini()
+
+	pager.Draw(screen)
+	if !statusCalled {
+		t.Fatal("StatusLine hook was not called")
+	}
+	if got := pagerCellRune(screen, 2, 1); got != 'L' {
+		t.Fatalf("status text rune = %q, want %q", got, 'L')
+	}
+
+	if result := pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, "/", tcell.ModNone)); !result.Handled {
+		t.Fatal("HandleKeyResult(/).Handled = false, want true")
+	}
+	if result := pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, "a", tcell.ModNone)); !result.Handled {
+		t.Fatal("HandleKeyResult(a).Handled = false, want true")
+	}
+	screen.Clear()
+	pager.Draw(screen)
+	if !promptCalled {
+		t.Fatal("PromptLine hook was not called")
+	}
+	if got := pagerCellRune(screen, 1, 1); got != 'f' {
+		t.Fatalf("prompt text rune = %q, want %q", got, 'f')
+	}
+}
+
 func TestPagerSetSearchMode(t *testing.T) {
 	pager := New(Config{TabWidth: 4, WrapMode: NoWrap, ShowStatus: true})
 	pager.SetSize(20, 2)
@@ -597,4 +655,25 @@ func TestPagerSearchPreservesWhitespace(t *testing.T) {
 	if !pager.SearchForward(" ") {
 		t.Fatal("SearchForward(space) = false, want true")
 	}
+}
+
+func pagerCellRune(screen tcell.Screen, x, y int) rune {
+	str, _, _ := screen.Get(x, y)
+	if str == "" {
+		return 0
+	}
+	return []rune(str)[0]
+}
+
+func newPagerMockScreen(t *testing.T, width, height int) tcell.Screen {
+	t.Helper()
+	term := vt.NewMockTerm(vt.MockOptSize{X: vt.Col(width), Y: vt.Row(height)})
+	screen, err := tcell.NewTerminfoScreenFromTty(term)
+	if err != nil {
+		t.Fatalf("failed to get mock screen: %v", err)
+	}
+	if err := screen.Init(); err != nil {
+		t.Fatalf("failed to initialize mock screen: %v", err)
+	}
+	return screen
 }

--- a/text.go
+++ b/text.go
@@ -25,6 +25,9 @@ type Text struct {
 	StatusPosition func(current, total, column int) string
 	// FollowMode is appended to the status bar while follow mode is active.
 	FollowMode string
+	// StatusLine can override the full left and right status bar text.
+	// When nil, the pager assembles the built-in status line from the fields above.
+	StatusLine func(StatusInfo) (left, right string)
 
 	// SearchEmpty is shown when an empty search is submitted.
 	SearchEmpty string
@@ -48,6 +51,9 @@ type Text struct {
 	LeftOverflowIndicator string
 	// RightOverflowIndicator marks undisplayed content to the right in no-wrap mode.
 	RightOverflowIndicator string
+	// PromptLine can override the full built-in prompt text.
+	// When nil, the pager uses the built-in prefix plus the current input buffer.
+	PromptLine func(PromptInfo) string
 }
 
 // DefaultText returns the built-in pager text bundle.

--- a/ui.go
+++ b/ui.go
@@ -1,0 +1,48 @@
+// Copyright 2026 Garrett D'Amore
+// SPDX-License-Identifier: Apache-2.0
+
+package goless
+
+// StatusInfo summarizes the built-in status bar state passed to Text.StatusLine.
+type StatusInfo struct {
+	// Search is the current committed or preview search state.
+	Search SearchState
+	// Following reports whether follow mode is active.
+	Following bool
+	// Message is the current status message appended by pager actions.
+	Message string
+	// Position is the current viewport position.
+	Position Position
+	// DefaultLeft is the built-in left status text.
+	DefaultLeft string
+	// DefaultRight is the built-in right status text.
+	DefaultRight string
+}
+
+// PromptKind identifies the active built-in prompt type.
+type PromptKind int
+
+const (
+	// PromptSearchForward is the "/" search prompt.
+	PromptSearchForward PromptKind = iota
+	// PromptSearchBackward is the "?" search prompt.
+	PromptSearchBackward
+	// PromptCommand is the ":" command prompt.
+	PromptCommand
+)
+
+// PromptInfo summarizes the built-in prompt state passed to Text.PromptLine.
+type PromptInfo struct {
+	// Kind identifies which built-in prompt is active.
+	Kind PromptKind
+	// Prefix is the built-in prompt prefix, such as "/[smart,sub] ".
+	Prefix string
+	// Input is the current editable prompt buffer.
+	Input string
+	// Error is the current prompt-side error indicator, such as an invalid regex.
+	Error string
+	// Search is the current committed or preview search state.
+	Search SearchState
+	// DefaultText is the built-in prompt text before any custom formatting.
+	DefaultText string
+}


### PR DESCRIPTION
## Summary
- add narrow status and prompt formatter hooks with  and 
- add chrome style slots for the status bar, prompt line, and prompt error text
- wire the hooks through pager/viewer text plumbing with viewer and pager coverage

## Testing
- go test ./...


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added customization hooks to override status bar and prompt text rendering.
  * Added styling configuration options for status bar, prompt, and prompt error states.

* **Documentation**
  * Updated documentation describing new configuration capabilities for status bar and prompt customization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->