### PR TITLE
Add SGR strikethrough support

### DIFF
--- a/internal/ansi/parser.go
+++ b/internal/ansi/parser.go
@@ -387,6 +387,8 @@ func (p *Parser) processSGR(body string) {
 			p.style.Italic = true
 		case code == 4:
 			p.style.Underline = true
+		case code == 9:
+			p.style.Strike = true
 		case code == 5:
 			p.style.Blink = true
 		case code == 7:
@@ -398,6 +400,8 @@ func (p *Parser) processSGR(body string) {
 			p.style.Italic = false
 		case code == 24:
 			p.style.Underline = false
+		case code == 29:
+			p.style.Strike = false
 		case code == 25:
 			p.style.Blink = false
 		case code == 27:

--- a/internal/ansi/parser_test.go
+++ b/internal/ansi/parser_test.go
@@ -76,6 +76,26 @@ func TestParserAppliesSGRAndShowsOSC(t *testing.T) {
 	}
 }
 
+func TestParserAppliesAndClearsStrikethrough(t *testing.T) {
+	recv := &recordReceiver{}
+	p := NewParser(recv)
+
+	input := "a\x1b[9mB\x1b[29mC"
+	if _, err := p.Write([]byte(input)); err != nil {
+		t.Fatalf("Write failed: %v", err)
+	}
+
+	if got, want := len(recv.events), 3; got != want {
+		t.Fatalf("event count = %d, want %d", got, want)
+	}
+	if !recv.events[1].style.Strike {
+		t.Fatal("strikethrough for B = false, want true")
+	}
+	if recv.events[2].style.Strike {
+		t.Fatal("strikethrough for C = true, want false")
+	}
+}
+
 func TestParserLiteralShowsSGRWithoutStyling(t *testing.T) {
 	recv := &recordReceiver{}
 	p := NewParserWithMode(recv, RenderLiteral)

--- a/internal/ansi/style.go
+++ b/internal/ansi/style.go
@@ -47,6 +47,7 @@ type Style struct {
 	Dim       bool
 	Italic    bool
 	Underline bool
+	Strike    bool
 	Blink     bool
 	Reverse   bool
 }

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -1034,6 +1034,7 @@ func (v *Viewer) toTCellStyle(style ansi.Style) tcell.Style {
 	tstyle = tstyle.Dim(style.Dim)
 	tstyle = tstyle.Italic(style.Italic)
 	tstyle = tstyle.Underline(style.Underline)
+	tstyle = tstyle.StrikeThrough(style.Strike)
 	tstyle = tstyle.Blink(style.Blink)
 	tstyle = tstyle.Reverse(style.Reverse)
 	return tstyle

--- a/pager_test.go
+++ b/pager_test.go
@@ -865,6 +865,23 @@ func TestPagerSetVisualizationReclampsHorizontalScroll(t *testing.T) {
 	}
 }
 
+func TestPagerRendersStrikethroughStyle(t *testing.T) {
+	pager := New(Config{TabWidth: 4, WrapMode: NoWrap})
+	pager.SetSize(8, 1)
+	if err := pager.AppendString("\x1b[9mX\x1b[29m\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	screen := newPagerMockScreen(t, 8, 1)
+	defer screen.Fini()
+
+	pager.Draw(screen)
+	if !pagerCellStyle(screen, 0, 0).HasStrikeThrough() {
+		t.Fatal("style at rendered strikethrough cell = not strike-through")
+	}
+}
+
 func TestPagerVisualizationWideMarkerClipsAfterHorizontalScroll(t *testing.T) {
 	pager := New(Config{
 		TabWidth: 4,

--- a/testdata/unicode-sample.txt
+++ b/testdata/unicode-sample.txt
@@ -35,6 +35,7 @@ beforeafter
 ANSI styles:
 [1mBold[0m
 [4mUnderline[0m
+[9mStrikethrough[0m
 [7mReverse[0m
 [31mRed[0m [32mGreen[0m [34mBlue[0m
 [38;5;208mPalette orange[0m


### PR DESCRIPTION
## Summary
- add ANSI SGR strikethrough support ( / )
- carry strikethrough through internal style state and viewer rendering
- add parser/render tests and update 

## Testing
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for strikethrough text styling. Users can now apply strikethrough formatting using standard ANSI escape sequences, which is properly rendered across the application's viewer and pager.

* **Tests**
  * Added comprehensive test coverage for strikethrough functionality, including verification of proper rendering and state management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->