### PR TITLE
Allow embedders to handle ':' commands

### DIFF
--- a/cmd/goless-demo/main.go
+++ b/cmd/goless-demo/main.go
@@ -59,6 +59,7 @@ func run() error {
 		Theme:            preset.Theme,
 		Visualization:    demoVisualization(hidden),
 		HyperlinkHandler: demoHyperlinkHandler(liveLinks),
+		CommandHandler:   demoCommandHandler(),
 		Chrome:           chromeCfg,
 		ShowStatus:       true,
 	})
@@ -236,6 +237,17 @@ func demoHyperlinkHandler(live bool) goless.HyperlinkHandler {
 				Underline(tcell.UnderlineStyleSolid),
 			Live:     live,
 			StyleSet: true,
+		}
+	}
+}
+
+func demoCommandHandler() func(goless.Command) goless.CommandResult {
+	return func(cmd goless.Command) goless.CommandResult {
+		switch cmd.Name {
+		case "q", "quit":
+			return goless.CommandResult{Handled: true, Quit: true}
+		default:
+			return goless.CommandResult{}
 		}
 	}
 }

--- a/cmd/goless-demo/main_test.go
+++ b/cmd/goless-demo/main_test.go
@@ -116,3 +116,17 @@ func TestDemoHyperlinkHandler(t *testing.T) {
 		t.Fatal("demo live hyperlink handler left link inert")
 	}
 }
+
+func TestDemoCommandHandler(t *testing.T) {
+	handler := demoCommandHandler()
+
+	if result := handler(goless.Command{Name: "quit"}); !result.Handled || !result.Quit {
+		t.Fatalf("quit command result = %+v, want handled quit", result)
+	}
+	if result := handler(goless.Command{Name: "q"}); !result.Handled || !result.Quit {
+		t.Fatalf("q command result = %+v, want handled quit", result)
+	}
+	if result := handler(goless.Command{Name: "next"}); result.Handled || result.Quit {
+		t.Fatalf("next command result = %+v, want unhandled", result)
+	}
+}

--- a/internal/view/command.go
+++ b/internal/view/command.go
@@ -1,0 +1,34 @@
+// Copyright 2026 Garrett D'Amore
+// SPDX-License-Identifier: Apache-2.0
+
+package view
+
+import "strings"
+
+type Command struct {
+	Raw  string
+	Name string
+	Args []string
+}
+
+type CommandResult struct {
+	Handled    bool
+	Quit       bool
+	Message    string
+	KeepPrompt bool
+}
+
+type CommandHandler func(Command) CommandResult
+
+func parseCommand(text string) Command {
+	fields := strings.Fields(text)
+	cmd := Command{Raw: text}
+	if len(fields) == 0 {
+		return cmd
+	}
+	cmd.Name = fields[0]
+	if len(fields) > 1 {
+		cmd.Args = append([]string(nil), fields[1:]...)
+	}
+	return cmd
+}

--- a/internal/view/search.go
+++ b/internal/view/search.go
@@ -255,24 +255,29 @@ func (v *Viewer) cancelPrompt() {
 	v.prompt = nil
 }
 
-func (v *Viewer) commitPrompt() {
+func (v *Viewer) commitPrompt() KeyResult {
 	if v.prompt == nil {
-		return
+		return KeyResult{}
 	}
 
 	text := string(v.prompt.buffer)
 	commit := true
+	quit := false
 	switch v.prompt.kind {
 	case promptSearchForward:
 		commit = v.commitPromptSearch(text, true)
 	case promptSearchBackward:
 		commit = v.commitPromptSearch(text, false)
 	case promptCommand:
-		v.runCommand(text)
+		commit, quit = v.runCommand(text)
 	}
 	if commit {
 		v.cancelPrompt()
 	}
+	if quit {
+		return KeyResult{Handled: true, Quit: true}
+	}
+	return KeyResult{Handled: true}
 }
 
 func (v *Viewer) commitPromptSearch(text string, forward bool) bool {
@@ -514,22 +519,34 @@ func (v *Viewer) revealMatchHorizontally(match searchMatch) {
 	v.relayout()
 }
 
-func (v *Viewer) runCommand(text string) {
+func (v *Viewer) runCommand(text string) (commit bool, quit bool) {
 	text = strings.TrimSpace(text)
 	if text == "" {
-		return
+		return true, false
 	}
 
 	if v.runSetCommand(text) {
-		return
+		return true, false
 	}
 
 	lineNumber, err := strconv.Atoi(text)
-	if err != nil {
-		v.message = v.text.CommandUnknown(text)
-		return
+	if err == nil {
+		v.goToLine(lineNumber)
+		return true, false
 	}
-	v.goToLine(lineNumber)
+
+	if v.cfg.CommandHandler != nil {
+		result := v.cfg.CommandHandler(parseCommand(text))
+		if result.Handled {
+			if result.Message != "" {
+				v.message = result.Message
+			}
+			return !result.KeepPrompt, result.Quit
+		}
+	}
+
+	v.message = v.text.CommandUnknown(text)
+	return true, false
 }
 
 func (v *Viewer) runSetCommand(text string) bool {

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -23,6 +23,7 @@ type Config struct {
 	Theme            Theme
 	Visualization    Visualization
 	HyperlinkHandler HyperlinkHandler
+	CommandHandler   CommandHandler
 	KeyGroup         KeyGroup
 	KeyUnbind        []KeyStroke
 	KeyBind          []KeyBinding
@@ -1088,8 +1089,7 @@ func (v *Viewer) handlePromptKey(ev *tcell.EventKey) KeyResult {
 		v.cancelPrompt()
 		return KeyResult{Handled: true}
 	case tcell.KeyEnter:
-		v.commitPrompt()
-		return KeyResult{Handled: true}
+		return v.commitPrompt()
 	case tcell.KeyBackspace, tcell.KeyBackspace2:
 		if v.prompt != nil && len(v.prompt.buffer) > 0 {
 			v.prompt.buffer = v.prompt.buffer[:len(v.prompt.buffer)-1]

--- a/pager.go
+++ b/pager.go
@@ -28,20 +28,21 @@ const (
 
 // Config configures a Pager.
 type Config struct {
-	TabWidth         int                        // TabWidth controls tab expansion during layout. Values <= 0 default to 8.
-	WrapMode         WrapMode                   // WrapMode selects horizontal scrolling or soft wrapping.
-	SearchCase       SearchCaseMode             // SearchCase selects smart-case, case-sensitive, or case-insensitive literal search behavior.
-	SearchMode       SearchMode                 // SearchMode selects substring, whole-word, or regex search behavior.
-	Theme            Theme                      // Theme remaps content default colors and ANSI 0-15 without affecting chrome.
-	Visualization    Visualization              // Visualization overlays optional markers for tabs, line endings, carriage returns, and EOF.
-	HyperlinkHandler HyperlinkHandler           // HyperlinkHandler controls how parsed OSC 8 hyperlink spans are rendered.
-	KeyGroup         KeyGroup                   // KeyGroup selects a bundled set of key bindings.
-	UnbindKeys       []KeyStroke                // UnbindKeys removes exact bindings from the selected key group.
-	KeyBindings      []KeyBinding               // KeyBindings prepend custom bindings ahead of bundled defaults.
-	RenderMode       RenderMode                 // RenderMode controls how escapes and control sequences are presented.
-	Chrome           Chrome                     // Chrome configures optional body framing and title display.
-	ShowStatus       bool                       // ShowStatus enables the status bar on the last screen row.
-	CaptureKey       func(*tcell.EventKey) bool // CaptureKey reserves keys for the embedder before normal pager handling.
+	TabWidth         int                         // TabWidth controls tab expansion during layout. Values <= 0 default to 8.
+	WrapMode         WrapMode                    // WrapMode selects horizontal scrolling or soft wrapping.
+	SearchCase       SearchCaseMode              // SearchCase selects smart-case, case-sensitive, or case-insensitive literal search behavior.
+	SearchMode       SearchMode                  // SearchMode selects substring, whole-word, or regex search behavior.
+	Theme            Theme                       // Theme remaps content default colors and ANSI 0-15 without affecting chrome.
+	Visualization    Visualization               // Visualization overlays optional markers for tabs, line endings, carriage returns, and EOF.
+	HyperlinkHandler HyperlinkHandler            // HyperlinkHandler controls how parsed OSC 8 hyperlink spans are rendered.
+	CommandHandler   func(Command) CommandResult // CommandHandler handles unknown ':' commands after built-in pager commands decline them.
+	KeyGroup         KeyGroup                    // KeyGroup selects a bundled set of key bindings.
+	UnbindKeys       []KeyStroke                 // UnbindKeys removes exact bindings from the selected key group.
+	KeyBindings      []KeyBinding                // KeyBindings prepend custom bindings ahead of bundled defaults.
+	RenderMode       RenderMode                  // RenderMode controls how escapes and control sequences are presented.
+	Chrome           Chrome                      // Chrome configures optional body framing and title display.
+	ShowStatus       bool                        // ShowStatus enables the status bar on the last screen row.
+	CaptureKey       func(*tcell.EventKey) bool  // CaptureKey reserves keys for the embedder before normal pager handling.
 
 	// Text controls user-facing text, help content, and UI indicators.
 	// Zero values are filled from DefaultText.
@@ -52,6 +53,21 @@ type Config struct {
 type KeyResult struct {
 	Handled bool
 	Quit    bool
+}
+
+// Command describes a ':' command entered through the built-in prompt.
+type Command struct {
+	Raw  string
+	Name string
+	Args []string
+}
+
+// CommandResult describes how an embedder handled a ':' command.
+type CommandResult struct {
+	Handled    bool
+	Quit       bool
+	Message    string
+	KeepPrompt bool
 }
 
 // Position summarizes the current visible pager viewport.
@@ -85,6 +101,7 @@ func New(cfg Config) *Pager {
 			Theme:            toInternalTheme(cfg.Theme),
 			Visualization:    toInternalVisualization(cfg.Visualization),
 			HyperlinkHandler: toInternalHyperlinkHandler(cfg.HyperlinkHandler),
+			CommandHandler:   toInternalCommandHandler(cfg.CommandHandler),
 			KeyGroup:         toInternalKeyGroup(cfg.KeyGroup),
 			KeyUnbind:        toInternalKeyStrokes(cfg.UnbindKeys),
 			KeyBind:          toInternalKeyBindings(cfg.KeyBindings),
@@ -518,6 +535,25 @@ func toInternalHyperlinkHandler(handler HyperlinkHandler) iview.HyperlinkHandler
 			Target:   decision.Target,
 			Style:    decision.Style,
 			StyleSet: decision.StyleSet,
+		}
+	}
+}
+
+func toInternalCommandHandler(handler func(Command) CommandResult) iview.CommandHandler {
+	if handler == nil {
+		return nil
+	}
+	return func(cmd iview.Command) iview.CommandResult {
+		result := handler(Command{
+			Raw:  cmd.Raw,
+			Name: cmd.Name,
+			Args: append([]string(nil), cmd.Args...),
+		})
+		return iview.CommandResult{
+			Handled:    result.Handled,
+			Quit:       result.Quit,
+			Message:    result.Message,
+			KeepPrompt: result.KeepPrompt,
 		}
 	}
 }

--- a/pager_test.go
+++ b/pager_test.go
@@ -92,7 +92,7 @@ func TestPagerCaptureKeyReservesBinding(t *testing.T) {
 			return ev.Key() == tcell.KeyRune && ev.Str() == "n"
 		},
 	})
-	pager.SetSize(20, 2)
+	pager.SetSize(30, 2)
 	if err := pager.AppendString("alpha\nbeta\nalpha\n"); err != nil {
 		t.Fatalf("AppendString failed: %v", err)
 	}
@@ -259,6 +259,159 @@ func TestPagerPromptKeyBindingOverridesBuiltins(t *testing.T) {
 	}
 	if !result.Quit {
 		t.Fatal("HandleKeyResult(Escape).Quit = false, want true for prompt override")
+	}
+}
+
+func TestPagerCommandHandlerHandlesUnknownCommand(t *testing.T) {
+	handled := false
+	pager := New(Config{
+		TabWidth:   4,
+		WrapMode:   NoWrap,
+		ShowStatus: true,
+		Text: Text{
+			StatusLine: func(info StatusInfo) (left, right string) {
+				return info.Message, ""
+			},
+		},
+		CommandHandler: func(cmd Command) CommandResult {
+			handled = true
+			if got, want := cmd.Raw, "next file"; got != want {
+				t.Fatalf("Command.Raw = %q, want %q", got, want)
+			}
+			if got, want := cmd.Name, "next"; got != want {
+				t.Fatalf("Command.Name = %q, want %q", got, want)
+			}
+			if got, want := strings.Join(cmd.Args, ","), "file"; got != want {
+				t.Fatalf("Command.Args = %q, want %q", got, want)
+			}
+			return CommandResult{
+				Handled: true,
+				Message: "advanced",
+			}
+		},
+	})
+	pager.SetSize(20, 2)
+	if err := pager.AppendString("alpha\nbeta\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	if result := pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, ":", tcell.ModNone)); !result.Handled {
+		t.Fatal("HandleKeyResult(:).Handled = false, want true")
+	}
+	for _, r := range "next file" {
+		pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, string(r), tcell.ModNone))
+	}
+	result := pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	if !result.Handled {
+		t.Fatal("HandleKeyResult(Enter).Handled = false, want true")
+	}
+	if result.Quit {
+		t.Fatal("HandleKeyResult(Enter).Quit = true, want false")
+	}
+	if !handled {
+		t.Fatal("CommandHandler was not called")
+	}
+
+	screen := newPagerMockScreen(t, 30, 2)
+	defer screen.Fini()
+	pager.Draw(screen)
+	if got := pagerRowString(screen, 1, 30); !strings.Contains(got, "advanced") {
+		t.Fatalf("status line = %q, want message", got)
+	}
+}
+
+func TestPagerCommandHandlerCanKeepPromptOpen(t *testing.T) {
+	pager := New(Config{
+		TabWidth:   4,
+		WrapMode:   NoWrap,
+		ShowStatus: true,
+		CommandHandler: func(cmd Command) CommandResult {
+			return CommandResult{
+				Handled:    true,
+				Message:    "need more",
+				KeepPrompt: true,
+			}
+		},
+	})
+	pager.SetSize(30, 2)
+	if err := pager.AppendString("alpha\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, ":", tcell.ModNone))
+	pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, "n", tcell.ModNone))
+	result := pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	if !result.Handled {
+		t.Fatal("HandleKeyResult(Enter).Handled = false, want true")
+	}
+	if result.Quit {
+		t.Fatal("HandleKeyResult(Enter).Quit = true, want false")
+	}
+
+	screen := newPagerMockScreen(t, 30, 2)
+	defer screen.Fini()
+	pager.Draw(screen)
+	if got := pagerRowString(screen, 1, 30); !strings.Contains(got, ":n") {
+		t.Fatalf("prompt line = %q, want command prompt to remain open", got)
+	}
+}
+
+func TestPagerCommandHandlerCanRequestQuit(t *testing.T) {
+	pager := New(Config{
+		TabWidth:   4,
+		WrapMode:   NoWrap,
+		ShowStatus: true,
+		CommandHandler: func(cmd Command) CommandResult {
+			return CommandResult{Handled: true, Quit: true}
+		},
+	})
+	pager.SetSize(20, 2)
+	if err := pager.AppendString("alpha\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, ":", tcell.ModNone))
+	pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, "q", tcell.ModNone))
+	result := pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	if !result.Handled {
+		t.Fatal("HandleKeyResult(Enter).Handled = false, want true")
+	}
+	if !result.Quit {
+		t.Fatal("HandleKeyResult(Enter).Quit = false, want true")
+	}
+}
+
+func TestPagerBuiltInCommandWinsBeforeCommandHandler(t *testing.T) {
+	handled := false
+	pager := New(Config{
+		TabWidth:   4,
+		WrapMode:   NoWrap,
+		ShowStatus: true,
+		CommandHandler: func(cmd Command) CommandResult {
+			handled = true
+			return CommandResult{Handled: true, Message: "override"}
+		},
+	})
+	pager.SetSize(20, 2)
+	if err := pager.AppendString("alpha\nbeta\ngamma\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, ":", tcell.ModNone))
+	pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, "2", tcell.ModNone))
+	result := pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
+	if !result.Handled {
+		t.Fatal("HandleKeyResult(Enter).Handled = false, want true")
+	}
+	if handled {
+		t.Fatal("CommandHandler was called for built-in line jump")
+	}
+	if got, want := pager.Position().Row, 2; got != want {
+		t.Fatalf("Position().Row = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a command callback for unknown ':' prompt commands
- keep built-in commands like :set and numeric line jumps ahead of the callback
- wire the demo to handle :q and :quit through the embedder command path

Fixes #16

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added customizable command handler system for extended command processing and control.
  * Handlers can manage prompt state, display status messages, and request application termination.
  * Built-in commands retain priority over custom handlers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->