### PR TITLE
Implement blank line squeezing

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ The main config knobs are:
 - `SearchCase`: `SearchSmartCase`, `SearchCaseSensitive`, or
   `SearchCaseInsensitive`
 - `SearchMode`: `SearchSubstring`, `SearchWholeWord`, or `SearchRegex`
+- `SqueezeBlankLines`: collapse consecutive empty logical lines into one visible line at view time
 - `LineNumbers`: enable an adaptive line-number gutter
 - `HeaderLines`: pin the first N logical lines at the top of the viewport
 - `HeaderColumns`: pin the first N display columns at the left edge of the viewport
@@ -199,10 +200,15 @@ The built-in pager UI exposes search mode controls directly:
 - the current mode is shown in the status bar and search prompt
 - `:set searchcase smart|case|nocase` is available as a fallback
 - `:set searchmode sub|word|regex` is available as a fallback
+- `:set squeeze on|off|toggle` is available as a fallback
 - `:set numbers on|off|toggle` is available as a fallback
 - `:set headers on|off|toggle|<n>` is available as a fallback
 - `:set headercols on|off|toggle|<n>` is available as a fallback
 - invalid regexes stay in the search prompt and are marked visibly until fixed
+
+`SqueezeBlankLines` is a view-time policy: raw input stays unchanged, while
+search, line numbers, and `JumpToLine` operate on the squeezed view when the
+option is enabled.
 
 Embedders are not locked to the bundled keys. They can:
 

--- a/cmd/goless-demo/main.go
+++ b/cmd/goless-demo/main.go
@@ -39,10 +39,11 @@ func run() error {
 	var quitAtEOF bool
 	var quitAtEOFFirst bool
 	var renderName string
+	var squeeze bool
 	var title string
 
 	flag.Usage = func() {
-		fmt.Fprintf(flag.CommandLine.Output(), "usage: goless-demo [-e|-E] [-preset none|dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-title text] [+line|+/pattern] [file ...]\n")
+		fmt.Fprintf(flag.CommandLine.Output(), "usage: goless-demo [-e|-E] [-preset none|dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [+line|+/pattern] [file ...]\n")
 	}
 	flag.BoolVar(&quitAtEOF, "e", false, "quit on the first forward command at EOF")
 	flag.BoolVar(&quitAtEOFFirst, "E", false, "quit when EOF is already visible on screen")
@@ -53,6 +54,7 @@ func run() error {
 	flag.BoolVar(&quitAtEOF, "quit-at-eof", false, "long form of -e")
 	flag.BoolVar(&quitAtEOFFirst, "QUIT-AT-EOF", false, "long form of -E")
 	flag.StringVar(&renderName, "render", "hybrid", "render mode: hybrid, literal, presentation")
+	flag.BoolVar(&squeeze, "squeeze", false, "collapse repeated blank lines in the current view")
 	flag.StringVar(&title, "title", "", "frame title")
 	flag.Parse()
 
@@ -107,6 +109,7 @@ func run() error {
 			session.chrome(chromeCfg),
 			hidden,
 			liveLinks,
+			squeeze,
 			session.commandHandler(func() error {
 				if reloadCurrent == nil {
 					return fmt.Errorf("file reload unavailable")
@@ -665,18 +668,20 @@ func newDemoPager(
 	chrome goless.Chrome,
 	hidden bool,
 	liveLinks bool,
+	squeeze bool,
 	commandHandler func(goless.Command) goless.CommandResult,
 ) *goless.Pager {
 	return goless.New(goless.Config{
-		TabWidth:         8,
-		WrapMode:         goless.NoWrap,
-		RenderMode:       renderMode,
-		Theme:            preset.Theme,
-		Visualization:    demoVisualization(hidden),
-		HyperlinkHandler: demoHyperlinkHandler(liveLinks),
-		CommandHandler:   commandHandler,
-		Chrome:           chrome,
-		ShowStatus:       true,
+		TabWidth:          8,
+		WrapMode:          goless.NoWrap,
+		RenderMode:        renderMode,
+		SqueezeBlankLines: squeeze,
+		Theme:             preset.Theme,
+		Visualization:     demoVisualization(hidden),
+		HyperlinkHandler:  demoHyperlinkHandler(liveLinks),
+		CommandHandler:    commandHandler,
+		Chrome:            chrome,
+		ShowStatus:        true,
 	})
 }
 

--- a/cmd/goless-demo/main_test.go
+++ b/cmd/goless-demo/main_test.go
@@ -367,6 +367,22 @@ func TestHandleDemoVisibleEOFActionRequiresForwardNavigation(t *testing.T) {
 	}
 }
 
+func TestNewDemoPagerPropagatesSqueezeMode(t *testing.T) {
+	pager := newDemoPager(
+		goless.RenderHybrid,
+		goless.Preset{},
+		goless.Chrome{},
+		false,
+		false,
+		true,
+		nil,
+	)
+
+	if !pager.SqueezeBlankLines() {
+		t.Fatal("newDemoPager(..., squeeze=true, ...) did not enable squeeze mode")
+	}
+}
+
 func TestDemoSessionCommandHandler(t *testing.T) {
 	session := newDemoSession([]string{"one.txt", "two.txt"}, demoStartup{})
 	reloads := 0

--- a/internal/view/search.go
+++ b/internal/view/search.go
@@ -626,6 +626,20 @@ func (v *Viewer) runSetCommand(text string) bool {
 		}
 		v.message = ""
 		return true
+	case "squeeze", "squeezeblanks", "blanklines":
+		switch fields[2] {
+		case "on", "true":
+			v.SetSqueezeBlankLines(true)
+		case "off", "false":
+			v.SetSqueezeBlankLines(false)
+		case "toggle":
+			v.SetSqueezeBlankLines(!v.SqueezeBlankLines())
+		default:
+			v.message = v.text.CommandUnknown(text)
+			return true
+		}
+		v.message = ""
+		return true
 	case "headers", "headerlines":
 		switch fields[2] {
 		case "on", "true":
@@ -706,7 +720,7 @@ func (v *Viewer) goToPercent(percent int) {
 	v.message = strconv.Itoa(percent) + "%"
 }
 
-// JumpToLine moves the viewport to the requested logical line.
+// JumpToLine moves the viewport to the requested visible line number.
 func (v *Viewer) JumpToLine(lineNumber int) bool {
 	v.goToLine(lineNumber)
 	return lineNumber > 0 && lineNumber <= len(v.lines)

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -18,43 +18,46 @@ import (
 
 // Config controls viewer behavior.
 type Config struct {
-	TabWidth         int
-	WrapMode         layout.WrapMode
-	SearchCase       SearchCaseMode
-	SearchMode       SearchMode
-	LineNumbers      bool
-	HeaderLines      int
-	HeaderColumns    int
-	Theme            Theme
-	Visualization    Visualization
-	HyperlinkHandler HyperlinkHandler
-	CommandHandler   CommandHandler
-	KeyGroup         KeyGroup
-	KeyUnbind        []KeyStroke
-	KeyBind          []KeyBinding
-	Chrome           Chrome
-	ShowStatus       bool
-	Text             Text
+	TabWidth          int
+	WrapMode          layout.WrapMode
+	SearchCase        SearchCaseMode
+	SearchMode        SearchMode
+	SqueezeBlankLines bool
+	LineNumbers       bool
+	HeaderLines       int
+	HeaderColumns     int
+	Theme             Theme
+	Visualization     Visualization
+	HyperlinkHandler  HyperlinkHandler
+	CommandHandler    CommandHandler
+	KeyGroup          KeyGroup
+	KeyUnbind         []KeyStroke
+	KeyBind           []KeyBinding
+	Chrome            Chrome
+	ShowStatus        bool
+	Text              Text
 }
 
 // Viewer is a minimal document viewer built on the model and layout packages.
 type Viewer struct {
-	doc        *model.Document
-	cfg        Config
-	mode       viewerMode
-	prompt     *promptState
-	message    string
-	search     searchState
-	text       Text
-	keys       keyMap
-	lines      []model.Line
-	layout     layout.Result
-	width      int
-	height     int
-	rowOffset  int
-	colOffset  int
-	follow     bool
-	helpOffset int
+	doc         *model.Document
+	cfg         Config
+	mode        viewerMode
+	prompt      *promptState
+	message     string
+	search      searchState
+	text        Text
+	keys        keyMap
+	sourceLines []model.Line
+	lines       []model.Line
+	lineMap     []int
+	layout      layout.Result
+	width       int
+	height      int
+	rowOffset   int
+	colOffset   int
+	follow      bool
+	helpOffset  int
 }
 
 // KeyResult summarizes how the viewer handled a key event.
@@ -120,6 +123,28 @@ func (v *Viewer) ToggleLineNumbers() {
 // LineNumbers reports whether the adaptive line-number gutter is enabled.
 func (v *Viewer) LineNumbers() bool {
 	return v.cfg.LineNumbers
+}
+
+// SetSqueezeBlankLines updates whether repeated blank lines are collapsed in the current view.
+func (v *Viewer) SetSqueezeBlankLines(enabled bool) {
+	if v.cfg.SqueezeBlankLines == enabled {
+		return
+	}
+	v.ensureLayout()
+	anchor := v.firstVisibleSourceAnchor()
+	v.cfg.SqueezeBlankLines = enabled
+	v.relayout()
+	if v.follow {
+		v.rowOffset = v.maxRowOffset()
+		v.clampOffsets()
+		return
+	}
+	v.restoreSourceAnchor(anchor)
+}
+
+// SqueezeBlankLines reports whether repeated blank lines are collapsed in the current view.
+func (v *Viewer) SqueezeBlankLines() bool {
+	return v.cfg.SqueezeBlankLines
 }
 
 // SetHeaderLines updates how many leading logical lines stay fixed at the top of the viewport.
@@ -591,7 +616,8 @@ func (v *Viewer) ensureLayout() {
 }
 
 func (v *Viewer) relayout() {
-	v.lines = v.doc.Lines()
+	v.sourceLines = v.doc.Lines()
+	v.lines, v.lineMap = squeezeBlankLines(v.sourceLines, v.cfg.SqueezeBlankLines)
 	v.layout = layout.Build(v.lines, layout.Config{
 		Width:            max(v.bodyContentWidth(), 1),
 		TabWidth:         v.cfg.TabWidth,
@@ -736,11 +762,22 @@ func (v *Viewer) firstVisibleAnchor() layout.Anchor {
 	return v.layout.AnchorForRow(rowIndex)
 }
 
+func (v *Viewer) firstVisibleSourceAnchor() layout.Anchor {
+	anchor := v.firstVisibleAnchor()
+	anchor.LineIndex = v.sourceLineIndex(anchor.LineIndex)
+	return anchor
+}
+
 func (v *Viewer) restoreAnchor(anchor layout.Anchor) {
 	if rowIndex := v.layout.RowIndexForAnchor(anchor); rowIndex >= 0 {
 		v.rowOffset = max(rowIndex-v.scrollableRowStartIndex(), 0)
 	}
 	v.clampOffsets()
+}
+
+func (v *Viewer) restoreSourceAnchor(anchor layout.Anchor) {
+	anchor.LineIndex = v.displayLineIndexForSource(anchor.LineIndex)
+	v.restoreAnchor(anchor)
 }
 
 func (v *Viewer) revealAnchor(anchor layout.Anchor) {
@@ -1333,6 +1370,36 @@ func (v *Viewer) bodyContentWidth() int {
 	return v.contentWidth()
 }
 
+func (v *Viewer) sourceLineIndex(displayLine int) int {
+	if displayLine < 0 {
+		return 0
+	}
+	if displayLine < len(v.lineMap) {
+		return v.lineMap[displayLine]
+	}
+	if len(v.sourceLines) == 0 {
+		return 0
+	}
+	return len(v.sourceLines) - 1
+}
+
+func (v *Viewer) displayLineIndexForSource(sourceLine int) int {
+	if sourceLine <= 0 || len(v.lineMap) == 0 {
+		return 0
+	}
+	if sourceLine >= len(v.sourceLines) {
+		return len(v.lineMap) - 1
+	}
+	displayLine := 0
+	for i, mapped := range v.lineMap {
+		if mapped > sourceLine {
+			break
+		}
+		displayLine = i
+	}
+	return displayLine
+}
+
 func (v *Viewer) bottomBarRows() int {
 	if v.mode == modeHelp {
 		return 0
@@ -1399,6 +1466,34 @@ func (v *Viewer) statusOverflow() (left, right bool) {
 	}
 
 	return v.colOffset > 0, v.colOffset < v.maxColOffset()
+}
+
+func squeezeBlankLines(lines []model.Line, enabled bool) ([]model.Line, []int) {
+	if len(lines) == 0 {
+		return nil, nil
+	}
+
+	if !enabled {
+		lineMap := make([]int, len(lines))
+		for i := range lines {
+			lineMap[i] = i
+		}
+		return lines, lineMap
+	}
+
+	squeezed := make([]model.Line, 0, len(lines))
+	lineMap := make([]int, 0, len(lines))
+	prevBlank := false
+	for i, line := range lines {
+		blank := len(line.Graphemes) == 0
+		if blank && prevBlank {
+			continue
+		}
+		squeezed = append(squeezed, line)
+		lineMap = append(lineMap, i)
+		prevBlank = blank
+	}
+	return squeezed, lineMap
 }
 
 func (v *Viewer) drawPrompt(screen tcell.Screen, y int) {

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -217,6 +217,28 @@ func TestSetHeadersCommandClearsPriorInvalidMessage(t *testing.T) {
 	}
 }
 
+func TestSetSqueezeCommand(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("one\n\n\nthree\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 4)
+
+	for _, command := range []string{"set squeeze on", "set squeeze toggle"} {
+		v.HandleKey(keyRune(":"))
+		for _, s := range command {
+			v.HandleKey(keyRune(string(s)))
+		}
+		v.HandleKey(keyKey(tcell.KeyEnter))
+	}
+
+	if v.SqueezeBlankLines() {
+		t.Fatal("SqueezeBlankLines after on+toggle = true, want false")
+	}
+}
+
 func TestSetHeaderColumnsCommand(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\ntwo\nthree\n")); err != nil {
@@ -858,6 +880,32 @@ func TestPromptCommandJumpsToLine(t *testing.T) {
 
 	if got, want := v.firstVisibleAnchor().LineIndex, 2; got != want {
 		t.Fatalf("visible line after :3 = %d, want %d", got, want)
+	}
+}
+
+func TestPromptCommandJumpsToSqueezedLine(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("one\n\n\nthree\nfour\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{
+		TabWidth:          4,
+		WrapMode:          layout.NoWrap,
+		ShowStatus:        true,
+		SqueezeBlankLines: true,
+	})
+	v.SetSize(20, 2)
+
+	v.HandleKey(keyRune(":"))
+	v.HandleKey(keyRune("3"))
+	v.HandleKey(keyKey(tcell.KeyEnter))
+
+	if got, want := v.firstVisibleAnchor().LineIndex, 2; got != want {
+		t.Fatalf("visible squeezed line after :3 = %d, want %d", got, want)
+	}
+	if got, want := v.lines[2].Text, "three"; got != want {
+		t.Fatalf("visible squeezed line text = %q, want %q", got, want)
 	}
 }
 
@@ -1829,6 +1877,56 @@ func TestDrawLineNumbersUsesAdaptiveGutterWidth(t *testing.T) {
 	}
 	if got := cellRune(screen, 2, 0); got != ' ' {
 		t.Fatalf("gutter separator rune = %q, want space", got)
+	}
+}
+
+func TestDrawLineNumbersUseSqueezedViewNumbering(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("one\n\n\nthree\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{
+		TabWidth:          4,
+		WrapMode:          layout.NoWrap,
+		LineNumbers:       true,
+		SqueezeBlankLines: true,
+	})
+	v.SetSize(8, 4)
+
+	_, screen := newMockScreen(t, 8, 4)
+	defer screen.Fini()
+	v.Draw(screen)
+
+	if got := cellRune(screen, 0, 0); got != '1' {
+		t.Fatalf("first line number rune = %q, want %q", got, '1')
+	}
+	if got := cellRune(screen, 0, 1); got != '2' {
+		t.Fatalf("squeezed blank line number rune = %q, want %q", got, '2')
+	}
+	if got := cellRune(screen, 0, 2); got != '3' {
+		t.Fatalf("third line number rune = %q, want %q", got, '3')
+	}
+}
+
+func TestSetSqueezeBlankLinesPreservesVisibleSourceLine(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("one\n\n\nthree\nfour\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap})
+	v.SetSize(20, 2)
+	v.ScrollDown(3)
+
+	if got, want := v.lines[v.firstVisibleAnchor().LineIndex].Text, "three"; got != want {
+		t.Fatalf("visible line before squeeze = %q, want %q", got, want)
+	}
+
+	v.SetSqueezeBlankLines(true)
+
+	if got, want := v.lines[v.firstVisibleAnchor().LineIndex].Text, "three"; got != want {
+		t.Fatalf("visible line after squeeze = %q, want %q", got, want)
 	}
 }
 

--- a/pager.go
+++ b/pager.go
@@ -28,24 +28,25 @@ const (
 
 // Config configures a Pager.
 type Config struct {
-	TabWidth         int                         // TabWidth controls tab expansion during layout. Values <= 0 default to 8.
-	WrapMode         WrapMode                    // WrapMode selects horizontal scrolling or soft wrapping.
-	SearchCase       SearchCaseMode              // SearchCase selects smart-case, case-sensitive, or case-insensitive literal search behavior.
-	SearchMode       SearchMode                  // SearchMode selects substring, whole-word, or regex search behavior.
-	LineNumbers      bool                        // LineNumbers enables an adaptive line-number gutter.
-	HeaderLines      int                         // HeaderLines pins the first N logical lines at the top of the viewport.
-	HeaderColumns    int                         // HeaderColumns pins the first N display columns at the left edge of the viewport.
-	Theme            Theme                       // Theme remaps content default colors and ANSI 0-15 without affecting chrome.
-	Visualization    Visualization               // Visualization overlays optional markers for tabs, line endings, carriage returns, and EOF.
-	HyperlinkHandler HyperlinkHandler            // HyperlinkHandler controls how parsed OSC 8 hyperlink spans are rendered.
-	CommandHandler   func(Command) CommandResult // CommandHandler handles unknown ':' commands after built-in pager commands decline them.
-	KeyGroup         KeyGroup                    // KeyGroup selects a bundled set of key bindings.
-	UnbindKeys       []KeyStroke                 // UnbindKeys removes exact bindings from the selected key group.
-	KeyBindings      []KeyBinding                // KeyBindings prepend custom bindings ahead of bundled defaults.
-	RenderMode       RenderMode                  // RenderMode controls how escapes and control sequences are presented.
-	Chrome           Chrome                      // Chrome configures optional body framing and title display.
-	ShowStatus       bool                        // ShowStatus enables the status bar on the last screen row.
-	CaptureKey       func(*tcell.EventKey) bool  // CaptureKey reserves keys for the embedder before normal pager handling.
+	TabWidth          int                         // TabWidth controls tab expansion during layout. Values <= 0 default to 8.
+	WrapMode          WrapMode                    // WrapMode selects horizontal scrolling or soft wrapping.
+	SearchCase        SearchCaseMode              // SearchCase selects smart-case, case-sensitive, or case-insensitive literal search behavior.
+	SearchMode        SearchMode                  // SearchMode selects substring, whole-word, or regex search behavior.
+	SqueezeBlankLines bool                        // SqueezeBlankLines collapses consecutive empty logical lines into a single visible line at view time.
+	LineNumbers       bool                        // LineNumbers enables an adaptive line-number gutter.
+	HeaderLines       int                         // HeaderLines pins the first N logical lines at the top of the viewport.
+	HeaderColumns     int                         // HeaderColumns pins the first N display columns at the left edge of the viewport.
+	Theme             Theme                       // Theme remaps content default colors and ANSI 0-15 without affecting chrome.
+	Visualization     Visualization               // Visualization overlays optional markers for tabs, line endings, carriage returns, and EOF.
+	HyperlinkHandler  HyperlinkHandler            // HyperlinkHandler controls how parsed OSC 8 hyperlink spans are rendered.
+	CommandHandler    func(Command) CommandResult // CommandHandler handles unknown ':' commands after built-in pager commands decline them.
+	KeyGroup          KeyGroup                    // KeyGroup selects a bundled set of key bindings.
+	UnbindKeys        []KeyStroke                 // UnbindKeys removes exact bindings from the selected key group.
+	KeyBindings       []KeyBinding                // KeyBindings prepend custom bindings ahead of bundled defaults.
+	RenderMode        RenderMode                  // RenderMode controls how escapes and control sequences are presented.
+	Chrome            Chrome                      // Chrome configures optional body framing and title display.
+	ShowStatus        bool                        // ShowStatus enables the status bar on the last screen row.
+	CaptureKey        func(*tcell.EventKey) bool  // CaptureKey reserves keys for the embedder before normal pager handling.
 
 	// Text controls user-facing text, help content, and UI indicators.
 	// Zero values are filled from DefaultText.
@@ -99,23 +100,24 @@ func New(cfg Config) *Pager {
 		doc:        doc,
 		captureKey: cfg.CaptureKey,
 		viewer: iview.New(doc, iview.Config{
-			TabWidth:         cfg.TabWidth,
-			WrapMode:         toInternalWrapMode(cfg.WrapMode),
-			SearchCase:       toInternalSearchCaseMode(cfg.SearchCase),
-			SearchMode:       toInternalSearchMode(cfg.SearchMode),
-			LineNumbers:      cfg.LineNumbers,
-			HeaderLines:      cfg.HeaderLines,
-			HeaderColumns:    cfg.HeaderColumns,
-			Theme:            toInternalTheme(cfg.Theme),
-			Visualization:    toInternalVisualization(cfg.Visualization),
-			HyperlinkHandler: toInternalHyperlinkHandler(cfg.HyperlinkHandler),
-			CommandHandler:   toInternalCommandHandler(cfg.CommandHandler),
-			KeyGroup:         toInternalKeyGroup(cfg.KeyGroup),
-			KeyUnbind:        toInternalKeyStrokes(cfg.UnbindKeys),
-			KeyBind:          toInternalKeyBindings(cfg.KeyBindings),
-			Chrome:           toInternalChrome(cfg.Chrome),
-			ShowStatus:       cfg.ShowStatus,
-			Text:             toInternalText(cfg.Text),
+			TabWidth:          cfg.TabWidth,
+			WrapMode:          toInternalWrapMode(cfg.WrapMode),
+			SearchCase:        toInternalSearchCaseMode(cfg.SearchCase),
+			SearchMode:        toInternalSearchMode(cfg.SearchMode),
+			SqueezeBlankLines: cfg.SqueezeBlankLines,
+			LineNumbers:       cfg.LineNumbers,
+			HeaderLines:       cfg.HeaderLines,
+			HeaderColumns:     cfg.HeaderColumns,
+			Theme:             toInternalTheme(cfg.Theme),
+			Visualization:     toInternalVisualization(cfg.Visualization),
+			HyperlinkHandler:  toInternalHyperlinkHandler(cfg.HyperlinkHandler),
+			CommandHandler:    toInternalCommandHandler(cfg.CommandHandler),
+			KeyGroup:          toInternalKeyGroup(cfg.KeyGroup),
+			KeyUnbind:         toInternalKeyStrokes(cfg.UnbindKeys),
+			KeyBind:           toInternalKeyBindings(cfg.KeyBindings),
+			Chrome:            toInternalChrome(cfg.Chrome),
+			ShowStatus:        cfg.ShowStatus,
+			Text:              toInternalText(cfg.Text),
 		}),
 	}
 }
@@ -200,6 +202,16 @@ func (p *Pager) ToggleLineNumbers() {
 // LineNumbers reports whether the adaptive line-number gutter is enabled.
 func (p *Pager) LineNumbers() bool {
 	return p.viewer.LineNumbers()
+}
+
+// SetSqueezeBlankLines updates whether repeated blank lines are collapsed in the current view.
+func (p *Pager) SetSqueezeBlankLines(enabled bool) {
+	p.viewer.SetSqueezeBlankLines(enabled)
+}
+
+// SqueezeBlankLines reports whether repeated blank lines are collapsed in the current view.
+func (p *Pager) SqueezeBlankLines() bool {
+	return p.viewer.SqueezeBlankLines()
 }
 
 // SetHeaderLines updates how many leading logical lines stay fixed at the top of the viewport.
@@ -411,7 +423,7 @@ func (p *Pager) ClearSearch() {
 	p.viewer.ClearSearch()
 }
 
-// JumpToLine moves the viewport to the requested logical line.
+// JumpToLine moves the viewport to the requested visible line number.
 func (p *Pager) JumpToLine(lineNumber int) bool {
 	return p.viewer.JumpToLine(lineNumber)
 }

--- a/pager_test.go
+++ b/pager_test.go
@@ -569,6 +569,18 @@ func TestPagerLineNumberToggle(t *testing.T) {
 	}
 }
 
+func TestPagerSqueezeBlankLines(t *testing.T) {
+	pager := New(Config{TabWidth: 4, WrapMode: NoWrap, ShowStatus: true})
+	if pager.SqueezeBlankLines() {
+		t.Fatal("SqueezeBlankLines() = true, want false by default")
+	}
+
+	pager.SetSqueezeBlankLines(true)
+	if !pager.SqueezeBlankLines() {
+		t.Fatal("SqueezeBlankLines() = false, want true after SetSqueezeBlankLines(true)")
+	}
+}
+
 func TestPagerHeaderLines(t *testing.T) {
 	pager := New(Config{TabWidth: 4, WrapMode: NoWrap, ShowStatus: true})
 	if got, want := pager.HeaderLines(), 0; got != want {
@@ -600,6 +612,27 @@ func TestPagerHeaderColumns(t *testing.T) {
 	pager.SetHeaderColumns(-1)
 	if got, want := pager.HeaderColumns(), 0; got != want {
 		t.Fatalf("HeaderColumns() after SetHeaderColumns(-1) = %d, want %d", got, want)
+	}
+}
+
+func TestPagerJumpToLineUsesSqueezedView(t *testing.T) {
+	pager := New(Config{
+		TabWidth:          4,
+		WrapMode:          NoWrap,
+		ShowStatus:        true,
+		SqueezeBlankLines: true,
+	})
+	pager.SetSize(20, 2)
+	if err := pager.AppendString("one\n\n\nthree\nfour\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	if !pager.JumpToLine(3) {
+		t.Fatal("JumpToLine(3) = false, want true")
+	}
+	if got, want := pager.Position().Row, 3; got != want {
+		t.Fatalf("Position().Row after squeezed JumpToLine = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add optional view-time blank-line squeezing to the pager and viewer configs
- expose squeeze toggles through the public API, `:set squeeze`, and the demo `-squeeze` flag
- document squeezed-view semantics for search, line numbers, and line jumps and add coverage for the new behavior

Closes #34.

## Testing
- go test ./...