### PR TITLE
Fix 1-based viewport columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,8 @@ The current exported `Pager` API is controller-oriented.
   `SearchCaseMode`, `SetSearchMode`, `SearchMode`, `CycleSearchCaseMode`,
   `CycleSearchMode`, `SearchState`, `ClearSearch`
 - View state: `Position`
+  `Position.Row` and `Position.Column` are 1-based visible coordinates when
+  content is present, so `(1,1)` is the top-left visible position
 
 The main config knobs are:
 
@@ -224,6 +226,7 @@ The built-in pager UI exposes search mode controls directly:
 - when otherwise idle, the left side of the status bar shows a subtle help hint: `F1 Help`
   Embedders can replace it with `Text.StatusHelpHint` or suppress it with `Text.HideStatusHelpHint`
 - the right side of the status bar shows row and column as `current/total`
+  These are 1-based visible coordinates, so the top-left visible position is `row 1`, `col 1`
 - the right side of the status bar adds contextual wrap/scroll glyphs such as `↪` and `⇆`
 - `:set searchcase smart|case|nocase` is available as a fallback
 - `:set searchmode sub|word|regex` is available as a fallback

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -651,13 +651,13 @@ func (v *Viewer) EOFVisible() bool {
 	return ok && rowIndex >= len(v.layout.Rows)-1
 }
 
-// Position reports the current visible row, total row count, horizontal offset, and maximum column span.
+// Position reports the current visible row, total row count, current visible column number, and maximum column span.
 func (v *Viewer) Position() Position {
 	v.ensureLayout()
 	return Position{
 		Row:     v.firstVisibleRow(),
 		Rows:    len(v.layout.Rows),
-		Column:  v.colOffset,
+		Column:  v.visibleColumn(),
 		Columns: v.maxContentColumns(),
 	}
 }
@@ -1523,7 +1523,8 @@ func (v *Viewer) statusText() (left, right string) {
 	}
 
 	current := v.firstVisibleRow()
-	right = v.text.StatusPosition(current, len(v.layout.Rows), v.colOffset, v.maxContentColumns())
+	column := v.visibleColumn()
+	right = v.text.StatusPosition(current, len(v.layout.Rows), column, v.maxContentColumns())
 	if modeHint := v.statusModeHint(); modeHint != "" {
 		if right != "" {
 			right += "  " + modeHint
@@ -1539,7 +1540,7 @@ func (v *Viewer) statusText() (left, right string) {
 			Position: Position{
 				Row:     current,
 				Rows:    len(v.layout.Rows),
-				Column:  v.colOffset,
+				Column:  column,
 				Columns: v.maxContentColumns(),
 			},
 			DefaultLeft:  left,
@@ -1566,6 +1567,13 @@ func (v *Viewer) statusOverflow() (left, right bool) {
 
 func (v *Viewer) maxContentColumns() int {
 	return v.maxColumns
+}
+
+func (v *Viewer) visibleColumn() int {
+	if columns := v.maxContentColumns(); columns > 0 {
+		return min(v.colOffset+1, columns)
+	}
+	return 0
 }
 
 func (v *Viewer) computeMaxContentColumns() int {

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -1875,7 +1875,7 @@ func TestStatusTextPlacesPositionOnRight(t *testing.T) {
 	if got, want := leftText, "F1 Help"; got != want {
 		t.Fatalf("left status text = %q, want %q", got, want)
 	}
-	if !strings.Contains(rightText, "row 1/2") || !strings.Contains(rightText, "col 0/5") || !strings.Contains(rightText, "⇆") {
+	if !strings.Contains(rightText, "row 1/2") || !strings.Contains(rightText, "col 1/5") || !strings.Contains(rightText, "⇆") {
 		t.Fatalf("right status text = %q, want row+col indicator with no-wrap glyph", rightText)
 	}
 }
@@ -2063,7 +2063,7 @@ func TestStatusTextShowsColumnTotalsWhenScrolled(t *testing.T) {
 	v.relayout()
 
 	_, rightText := v.statusText()
-	if !strings.Contains(rightText, "col 3/10") {
+	if !strings.Contains(rightText, "col 4/10") {
 		t.Fatalf("right status text = %q, want column total", rightText)
 	}
 	if !strings.Contains(rightText, "⇆") {
@@ -2126,8 +2126,8 @@ func TestStatusLineFormatterOverridesBuiltInStatusText(t *testing.T) {
 	if got, want := leftText, "L:F1 Help"; got != want {
 		t.Fatalf("left status text = %q, want %q", got, want)
 	}
-	if !strings.HasPrefix(rightText, "R:row 1/2  col 0/5") {
-		t.Fatalf("right status text = %q, want prefix %q", rightText, "R:row 1/2  col 0/5")
+	if !strings.HasPrefix(rightText, "R:row 1/2  col 1/5") {
+		t.Fatalf("right status text = %q, want prefix %q", rightText, "R:row 1/2  col 1/5")
 	}
 }
 

--- a/pager.go
+++ b/pager.go
@@ -77,10 +77,16 @@ type CommandResult struct {
 }
 
 // Position summarizes the current visible pager viewport.
+// Row and Column are 1-based visible coordinates when content is present, so
+// (1, 1) is the top-left corner of the current viewport. An empty viewport
+// reports Row=0 and Column=0.
 type Position struct {
-	Row     int
-	Rows    int
-	Column  int
+	Row int
+	// Rows is the total visible row count.
+	Rows int
+	// Column is the 1-based visible column number, or 0 when no content is visible.
+	Column int
+	// Columns is the maximum visible content width in columns.
 	Columns int
 }
 
@@ -439,7 +445,9 @@ func (p *Pager) JumpToLine(lineNumber int) bool {
 	return p.viewer.JumpToLine(lineNumber)
 }
 
-// Position reports the current visible row, total row count, horizontal offset, and maximum column span.
+// Position reports the current visible row, total row count, current visible
+// column number, and maximum column span. Row and Column are 1-based when
+// content is present, so (1, 1) is the top-left visible position.
 func (p *Pager) Position() Position {
 	pos := p.viewer.Position()
 	return Position{

--- a/pager_test.go
+++ b/pager_test.go
@@ -491,7 +491,7 @@ func TestPagerWrapModeAndPosition(t *testing.T) {
 	pager.ScrollRight(3)
 
 	pos := pager.Position()
-	if got, want := pos.Column, 3; got != want {
+	if got, want := pos.Column, 4; got != want {
 		t.Fatalf("Position().Column = %d, want %d", got, want)
 	}
 	if got, want := pos.Columns, 10; got != want {
@@ -505,8 +505,8 @@ func TestPagerWrapModeAndPosition(t *testing.T) {
 	if got, want := pager.WrapMode(), SoftWrap; got != want {
 		t.Fatalf("WrapMode() after SetWrapMode = %v, want %v", got, want)
 	}
-	if got := pager.Position().Column; got != 0 {
-		t.Fatalf("Position().Column after SoftWrap = %d, want 0", got)
+	if got := pager.Position().Column; got != 1 {
+		t.Fatalf("Position().Column after SoftWrap = %d, want 1", got)
 	}
 	if got, want := pager.Position().Columns, 10; got != want {
 		t.Fatalf("Position().Columns after SoftWrap = %d, want %d", got, want)

--- a/text.go
+++ b/text.go
@@ -22,6 +22,7 @@ type Text struct {
 	// StatusSearchInfo formats the left-side status text for an active search.
 	StatusSearchInfo func(query string, current, total int) string
 	// StatusPosition formats the right-side position text in the status bar.
+	// current and column are 1-based visible coordinates.
 	StatusPosition func(current, total, column, columns int) string
 	// StatusHelpHint is shown on the left side of the status bar when no other status text is active.
 	StatusHelpHint string

--- a/ui.go
+++ b/ui.go
@@ -11,7 +11,8 @@ type StatusInfo struct {
 	Following bool
 	// Message is the current status message appended by pager actions.
 	Message string
-	// Position is the current viewport position.
+	// Position is the current viewport position. Row and Column are 1-based when
+	// content is present, and 0 when no content is visible.
 	Position Position
 	// DefaultLeft is the built-in left status text.
 	DefaultLeft string


### PR DESCRIPTION
Closes #55

## Summary
- report visible columns as 1-based in `Position()` and the built-in status text
- keep internal scrolling offsets zero-based
- document that `Position.Row` and `Position.Column` are 1-based visible coordinates and that `(1,1)` is the top-left visible position

## Testing
- go test ./...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Position coordinates now report 1-based visible positions (row/col), so the top-left visible cell is (1,1) and status/position displays reflect visible column numbers rather than raw scroll offsets.

* **Documentation**
  * Clarified docs and status text descriptions to state that row and column values are 1-based visible coordinates and to show totals using the same semantics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->