### PR TITLE
Fix follow mode EOF after resize

### DIFF
--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -354,6 +354,10 @@ func (v *Viewer) SetSize(width, height int) {
 	v.height = height
 	v.relayout()
 	v.clampHelpOffset()
+	if v.follow {
+		v.rowOffset = v.maxRowOffset()
+		v.clampOffsets()
+	}
 }
 
 // Refresh rebuilds the derived layout using the current document contents.

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -1602,6 +1602,33 @@ func TestRefreshInFollowModeStaysAtBottomAfterAppend(t *testing.T) {
 	}
 }
 
+func TestSetSizeInFollowModeRepinsToEOF(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("one\ntwo\nthree\nfour\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 4)
+	v.Follow()
+
+	if !v.EOFVisible() {
+		t.Fatal("EOF visible before resize = false, want true")
+	}
+
+	v.SetSize(20, 2)
+
+	if !v.Following() {
+		t.Fatalf("follow mode after resize = false, want true")
+	}
+	if !v.EOFVisible() {
+		t.Fatal("EOF visible after resize = false, want true")
+	}
+	if got, want := v.rowOffset, v.maxRowOffset(); got != want {
+		t.Fatalf("row offset after resize = %d, want %d", got, want)
+	}
+}
+
 func TestScrollUpExitsFollowMode(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\ntwo\nthree\n")); err != nil {


### PR DESCRIPTION
## Summary
- repin the viewport to the new bottom when `SetSize` runs in follow mode
- preserve the follow-mode invariant that EOF stays visible after resize
- add a regression test covering a shrinking viewport while following

## Testing
- go test ./...

Closes #42