### PR TITLE
Fix invalid mobile width rule for page-shell

### DIFF
--- a/site/static/styles.css
+++ b/site/static/styles.css
@@ -430,7 +430,7 @@ img {
 
 @media (max-width: 560px) {
   .page-shell {
-    width: min(100% - 20px, 1120px);
+    width: min(calc(100% - 20px), 1120px);
     padding-top: 16px;
   }
 


### PR DESCRIPTION
## Summary
- wrap the mobile `.page-shell` width subtraction in `calc(...)` so the CSS declaration is valid
- preserve the intended 10px side gutters on narrow screens

## Testing
- go test ./...

Fixes #67

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed mobile responsive layout on smaller screens to ensure proper page width calculations and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->