### PR TITLE
Preserve standalone chrome overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ Program flags:
 - `-hidden`
 - `-live-links`
 - `-render hybrid|literal|presentation`
+- `-squeeze` to collapse repeated blank lines in the current view
 - `-title text`
 - optional `+line` or `+/pattern` startup directive before paths
 - `-` as an explicit stdin path

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -880,25 +880,7 @@ func newProgramPager(
 }
 
 func programChrome(name, title string, base goless.Chrome) (goless.Chrome, error) {
-	chrome := goless.Chrome{
-		TitleAlign:       base.TitleAlign,
-		Title:            base.Title,
-		BorderStyle:      base.BorderStyle,
-		TitleStyle:       base.TitleStyle,
-		StatusStyle:      base.StatusStyle,
-		LineNumberStyle:  base.LineNumberStyle,
-		HeaderStyle:      base.HeaderStyle,
-		PromptStyle:      base.PromptStyle,
-		PromptErrorStyle: base.PromptErrorStyle,
-		Frame: goless.Frame{
-			Horizontal:  base.Frame.Horizontal,
-			Vertical:    base.Frame.Vertical,
-			TopLeft:     base.Frame.TopLeft,
-			TopRight:    base.Frame.TopRight,
-			BottomLeft:  base.Frame.BottomLeft,
-			BottomRight: base.Frame.BottomRight,
-		},
-	}
+	chrome := base
 	if title != "" {
 		chrome.Title = title
 	}

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -51,6 +51,16 @@ func TestDemoChromeUsesPresetAndOverrides(t *testing.T) {
 		t.Fatalf("programChrome(single).Title = %q, want %q", got, want)
 	}
 
+	base := goless.PrettyPreset.Chrome
+	base.StatusHelpKeyStyle = tcell.StyleDefault.Foreground(tcolor.Red).Bold(true)
+	chrome, err = programChrome("single", "Demo", base)
+	if err != nil {
+		t.Fatalf("programChrome(single, custom help style) failed: %v", err)
+	}
+	if got, want := chrome.StatusHelpKeyStyle, base.StatusHelpKeyStyle; got != want {
+		t.Fatalf("programChrome(single).StatusHelpKeyStyle = %#v, want %#v", got, want)
+	}
+
 	chrome, err = programChrome("none", "", goless.PrettyPreset.Chrome)
 	if err != nil {
 		t.Fatalf("programChrome(none) failed: %v", err)


### PR DESCRIPTION
Fixes #60

## Summary
- preserve the full base chrome when applying standalone chrome overrides
- add a regression test for custom status help key styling
- document the `-squeeze` flag in the README program flag list

## Testing
- go test ./cmd/goless