### PR TITLE
Use logical coordinates for pager position and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,8 +180,8 @@ The current exported `Pager` API is controller-oriented.
   `SearchCaseMode`, `SetSearchMode`, `SearchMode`, `CycleSearchCaseMode`,
   `CycleSearchMode`, `SearchState`, `ClearSearch`
 - View state: `Position`
-  `Position.Row` and `Position.Column` are 1-based visible coordinates when
-  content is present, so `(1,1)` is the top-left visible position
+  `Position.Row` and `Position.Column` are 1-based logical coordinates when
+  content is present, so `(1,1)` is the start of the first logical line
 
 The main constructor/runtime options are available both as explicit `With...`
 helpers and, for construction compatibility, through `Config` passed to `New`.
@@ -234,7 +234,8 @@ The built-in pager UI exposes search mode controls directly:
 - when otherwise idle, the left side of the status bar shows a subtle help hint: `F1 Help`
   Embedders can replace it with `Text.StatusHelpHint` or suppress it with `Text.HideStatusHelpHint`
 - the right side of the status bar shows row and column as `current/total`
-  These are 1-based visible coordinates, so the top-left visible position is `row 1`, `col 1`
+  These are 1-based logical coordinates rather than wrapped visual row numbers
+- the built-in status bar appends `EOF` when the end of the document is visible
 - the right side of the status bar adds contextual wrap/scroll glyphs such as `↪` and `⇆`
 - `:set searchcase smart|case|nocase` is available as a fallback
 - `:set searchmode sub|word|regex` is available as a fallback
@@ -244,9 +245,10 @@ The built-in pager UI exposes search mode controls directly:
 - `:set headercols on|off|toggle|<n>` is available as a fallback
 - invalid regexes stay in the search prompt and are marked visibly until fixed
 
-`SqueezeBlankLines` is a view-time policy: raw input stays unchanged, while
-search, line numbers, and `JumpToLine` operate on the squeezed view when the
-option is enabled.
+`SqueezeBlankLines` is a view-time policy: raw input stays unchanged and
+consecutive blank lines may be rendered as a single visible blank line, but
+logical line numbering remains source-based for `Position()`, line numbers, and
+`JumpToLine`.
 
 Embedders are not locked to the bundled keys. They can:
 

--- a/internal/view/search.go
+++ b/internal/view/search.go
@@ -795,7 +795,7 @@ func (v *Viewer) goToLine(lineNumber int) {
 	v.follow = false
 	v.ensureLayout()
 	lineIndex := lineNumber - 1
-	if lineIndex >= len(v.lines) {
+	if lineIndex >= len(v.sourceLines) {
 		v.message = v.text.CommandOutOfRange(lineNumber)
 		return
 	}
@@ -803,7 +803,7 @@ func (v *Viewer) goToLine(lineNumber int) {
 		v.colOffset = 0
 		v.relayout()
 	}
-	v.restoreAnchor(layout.Anchor{LineIndex: lineIndex, GraphemeIndex: 0})
+	v.restoreSourceAnchor(layout.Anchor{LineIndex: lineIndex, GraphemeIndex: 0})
 	v.message = v.text.CommandLine(lineNumber)
 }
 
@@ -818,10 +818,10 @@ func (v *Viewer) goToPercent(percent int) {
 	v.message = strconv.Itoa(percent) + "%"
 }
 
-// JumpToLine moves the viewport to the requested visible line number.
+// JumpToLine moves the viewport to the requested logical line number.
 func (v *Viewer) JumpToLine(lineNumber int) bool {
 	v.goToLine(lineNumber)
-	return lineNumber > 0 && lineNumber <= len(v.lines)
+	return lineNumber > 0 && lineNumber <= len(v.sourceLines)
 }
 
 func (v *Viewer) graphemeMatched(line model.Line, lineIndex int, grapheme model.Grapheme) (bool, bool) {

--- a/internal/view/text.go
+++ b/internal/view/text.go
@@ -22,6 +22,7 @@ type Text struct {
 	StatusHelpHint     string
 	HideStatusHelpHint bool
 	FollowMode         string
+	StatusEOF          string
 	StatusLine         func(StatusInfo) (left, right string)
 
 	SearchEmpty      string
@@ -70,6 +71,9 @@ func (t Text) withDefaults() Text {
 	if t.FollowMode == "" {
 		t.FollowMode = defaults.FollowMode
 	}
+	if t.StatusEOF == "" {
+		t.StatusEOF = defaults.StatusEOF
+	}
 	if t.SearchEmpty == "" {
 		t.SearchEmpty = defaults.SearchEmpty
 	}
@@ -117,6 +121,7 @@ func defaultText() Text {
 		},
 		StatusHelpHint: "F1 Help",
 		FollowMode:     "follow",
+		StatusEOF:      "EOF",
 		SearchEmpty:    "empty search",
 		SearchNotFound: func(query string) string {
 			return fmt.Sprintf("%s not found", query)

--- a/internal/view/ui.go
+++ b/internal/view/ui.go
@@ -7,6 +7,7 @@ package view
 type StatusInfo struct {
 	Search       SearchSnapshot
 	Following    bool
+	EOFVisible   bool
 	Message      string
 	Position     Position
 	DefaultLeft  string

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -71,7 +71,7 @@ type KeyResult struct {
 	Context KeyContext
 }
 
-// Position summarizes the current visible viewport state.
+// Position summarizes the current logical viewport state.
 type Position struct {
 	Row     int
 	Rows    int
@@ -703,16 +703,25 @@ func (v *Viewer) EOFVisible() bool {
 		return true
 	}
 	rowIndex, ok := v.lastVisibleLayoutRow()
-	return ok && rowIndex >= len(v.layout.Rows)-1
+	if !ok || rowIndex != len(v.layout.Rows)-1 {
+		return false
+	}
+	row := v.layout.Rows[rowIndex]
+	if row.LineIndex < 0 || row.LineIndex >= len(v.layout.Lines) {
+		return false
+	}
+	return row.SourceCellEnd >= v.layout.Lines[row.LineIndex].TotalCells
 }
 
-// Position reports the current visible row, total row count, current visible column number, and maximum column span.
+// Position reports the current logical line, total logical line count, current
+// logical display column, and maximum logical content span.
 func (v *Viewer) Position() Position {
 	v.ensureLayout()
+	rowIndex, ok := v.positionRowIndex()
 	return Position{
-		Row:     v.firstVisibleRow(),
-		Rows:    len(v.layout.Rows),
-		Column:  v.visibleColumn(),
+		Row:     v.logicalRowNumber(rowIndex, ok),
+		Rows:    len(v.sourceLines),
+		Column:  v.logicalColumnNumber(rowIndex, ok),
 		Columns: v.maxContentColumns(),
 	}
 }
@@ -771,30 +780,12 @@ func (v *Viewer) maxColOffset() int {
 	if v.cfg.WrapMode != layout.NoWrap {
 		return 0
 	}
-	return max(v.maxContentColumns()-max(v.bodyContentWidth(), 1), 0)
+	return max(v.maxScrollableColumns()-max(v.bodyContentWidth(), 1), 0)
 }
 
 func (v *Viewer) bodyHeight() int {
 	_, _, _, h := v.contentRect()
 	return h
-}
-
-func (v *Viewer) firstVisibleRow() int {
-	v.ensureLayout()
-	if len(v.layout.Rows) == 0 {
-		return 0
-	}
-	if v.visibleHeaderRowCount() > 0 {
-		rowIndex := v.scrollableRowStartIndex() + v.rowOffset
-		if rowIndex >= 0 && rowIndex < len(v.layout.Rows) {
-			return rowIndex + 1
-		}
-	}
-	rowIndex, _, ok := v.visibleLayoutRowAt(0)
-	if !ok || rowIndex < 0 {
-		return 0
-	}
-	return min(rowIndex+1, len(v.layout.Rows))
 }
 
 func (v *Viewer) headerLineCount() int {
@@ -1359,7 +1350,7 @@ func (v *Viewer) drawLineNumberGutter(screen tcell.Screen) {
 		if !v.shouldShowLineNumber(rowIndex) {
 			continue
 		}
-		label := padRightToWidth(fmt.Sprintf("%*d", gutterWidth-1, row.LineIndex+1), gutterWidth)
+		label := padRightToWidth(fmt.Sprintf("%*d", gutterWidth-1, v.sourceLineIndex(row.LineIndex)+1), gutterWidth)
 		screen.PutStrStyled(gutterX, gutterY+y, label, rowTextStyle)
 	}
 }
@@ -1415,7 +1406,7 @@ func (v *Viewer) lineNumberGutterWidth(available int) int {
 	if !v.cfg.LineNumbers || v.mode == modeHelp || available <= 1 {
 		return 0
 	}
-	digits := len(strconv.Itoa(max(len(v.lines), 1)))
+	digits := len(strconv.Itoa(max(len(v.sourceLines), 1)))
 	width := digits + 1
 	return min(width, available-1)
 }
@@ -1577,9 +1568,17 @@ func (v *Viewer) statusText() (left, right string) {
 		left = v.text.StatusHelpHint
 	}
 
-	current := v.firstVisibleRow()
-	column := v.visibleColumn()
-	right = v.text.StatusPosition(current, len(v.layout.Rows), column, v.maxContentColumns())
+	rowIndex, ok := v.positionRowIndex()
+	current := v.logicalRowNumber(rowIndex, ok)
+	column := v.logicalColumnNumber(rowIndex, ok)
+	right = v.text.StatusPosition(current, len(v.sourceLines), column, v.maxContentColumns())
+	if v.EOFVisible() {
+		if right != "" {
+			right += "  " + v.text.StatusEOF
+		} else {
+			right = v.text.StatusEOF
+		}
+	}
 	if modeHint := v.statusModeHint(); modeHint != "" {
 		if right != "" {
 			right += "  " + modeHint
@@ -1589,12 +1588,13 @@ func (v *Viewer) statusText() (left, right string) {
 	}
 	if v.text.StatusLine != nil {
 		return v.text.StatusLine(StatusInfo{
-			Search:    v.SearchSnapshot(),
-			Following: v.follow,
-			Message:   v.message,
+			Search:     v.SearchSnapshot(),
+			Following:  v.follow,
+			EOFVisible: v.EOFVisible(),
+			Message:    v.message,
 			Position: Position{
 				Row:     current,
-				Rows:    len(v.layout.Rows),
+				Rows:    len(v.sourceLines),
 				Column:  column,
 				Columns: v.maxContentColumns(),
 			},
@@ -1624,15 +1624,11 @@ func (v *Viewer) maxContentColumns() int {
 	return v.maxColumns
 }
 
-func (v *Viewer) visibleColumn() int {
-	if columns := v.maxContentColumns(); columns > 0 {
-		return min(v.colOffset+1, columns)
-	}
-	return 0
+func (v *Viewer) maxScrollableColumns() int {
+	return max(v.maxContentColumns()-v.headerColumnWidth(v.rawContentWidth()), 0)
 }
 
 func (v *Viewer) computeMaxContentColumns() int {
-	frozen := v.headerColumnWidth(v.rawContentWidth())
 	maxCells := 0
 	for i, line := range v.layout.Lines {
 		totalCells := line.TotalCells + v.trailingMarkerCellWidth(i)
@@ -1640,7 +1636,41 @@ func (v *Viewer) computeMaxContentColumns() int {
 			maxCells = totalCells
 		}
 	}
-	return max(maxCells-frozen, 0)
+	return maxCells
+}
+
+func (v *Viewer) positionRowIndex() (int, bool) {
+	v.ensureLayout()
+	if len(v.layout.Rows) == 0 {
+		return 0, false
+	}
+	rowIndex := v.scrollableRowStartIndex() + v.rowOffset
+	if rowIndex >= 0 && rowIndex < len(v.layout.Rows) {
+		return rowIndex, true
+	}
+	rowIndex, _, ok := v.visibleLayoutRowAt(0)
+	if !ok || rowIndex < 0 {
+		return 0, false
+	}
+	return rowIndex, true
+}
+
+func (v *Viewer) logicalRowNumber(rowIndex int, ok bool) int {
+	if !ok || rowIndex < 0 || rowIndex >= len(v.layout.Rows) {
+		return 0
+	}
+	return v.sourceLineIndex(v.layout.Rows[rowIndex].LineIndex) + 1
+}
+
+func (v *Viewer) logicalColumnNumber(rowIndex int, ok bool) int {
+	if !ok || rowIndex < 0 || rowIndex >= len(v.layout.Rows) {
+		return 0
+	}
+	columns := v.maxContentColumns()
+	if columns <= 0 {
+		return 0
+	}
+	return min(v.layout.Rows[rowIndex].SourceCellStart+1, columns)
 }
 
 func squeezeBlankLines(lines []model.Line, enabled bool) ([]model.Line, []int) {

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -1480,7 +1480,28 @@ func TestPromptCommandJumpsToLine(t *testing.T) {
 	}
 }
 
-func TestPromptCommandJumpsToSqueezedLine(t *testing.T) {
+func TestPromptCommandJumpsToLogicalLineInWrap(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("abcdef\nsecond\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.SoftWrap, ShowStatus: true})
+	v.SetSize(4, 2)
+
+	v.HandleKey(keyRune(":"))
+	v.HandleKey(keyRune("2"))
+	v.HandleKey(keyKey(tcell.KeyEnter))
+
+	if got, want := v.Position().Row, 2; got != want {
+		t.Fatalf("Position().Row after :2 = %d, want %d", got, want)
+	}
+	if got, want := v.firstVisibleAnchor(), (layout.Anchor{LineIndex: 1, GraphemeIndex: 0}); got != want {
+		t.Fatalf("anchor after :2 = %+v, want %+v", got, want)
+	}
+}
+
+func TestPromptCommandJumpsToSourceLineWhenSqueezed(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\n\n\nthree\nfour\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -1495,11 +1516,11 @@ func TestPromptCommandJumpsToSqueezedLine(t *testing.T) {
 	v.SetSize(20, 2)
 
 	v.HandleKey(keyRune(":"))
-	v.HandleKey(keyRune("3"))
+	v.HandleKey(keyRune("4"))
 	v.HandleKey(keyKey(tcell.KeyEnter))
 
 	if got, want := v.firstVisibleAnchor().LineIndex, 2; got != want {
-		t.Fatalf("visible squeezed line after :3 = %d, want %d", got, want)
+		t.Fatalf("visible squeezed line after :4 = %d, want %d", got, want)
 	}
 	if got, want := v.lines[2].Text, "three"; got != want {
 		t.Fatalf("visible squeezed line text = %q, want %q", got, want)
@@ -1977,6 +1998,22 @@ func TestStatusTextPlacesPositionOnRight(t *testing.T) {
 	}
 }
 
+func TestStatusTextUsesLogicalCoordinatesInSoftWrap(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("abcdefgh\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.SoftWrap, ShowStatus: true})
+	v.SetSize(4, 2)
+	v.ScrollDown(1)
+
+	_, rightText := v.statusText()
+	if !strings.Contains(rightText, "row 1/1") || !strings.Contains(rightText, "col 5/8") {
+		t.Fatalf("right status text = %q, want logical row+col indicator", rightText)
+	}
+}
+
 func TestStatusTextAndPositionAgreeWithFixedHeaders(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("h1\nh2\nbody1\nbody2\n")); err != nil {
@@ -1994,6 +2031,37 @@ func TestStatusTextAndPositionAgreeWithFixedHeaders(t *testing.T) {
 	_, rightText := v.statusText()
 	if !strings.Contains(rightText, "row 3/4") {
 		t.Fatalf("right status text = %q, want row indicator for first visible body row", rightText)
+	}
+}
+
+func TestStatusTextShowsEOFWhenVisible(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alpha\nbeta\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 3)
+	v.relayout()
+
+	_, rightText := v.statusText()
+	if !strings.Contains(rightText, "EOF") {
+		t.Fatalf("right status text = %q, want EOF indicator", rightText)
+	}
+}
+
+func TestEOFVisibleRequiresLineEndToBeVisibleInNoWrap(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("abcdefghijklmnopqrstuvwxyz\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(10, 2)
+	v.relayout()
+
+	if v.EOFVisible() {
+		t.Fatal("EOFVisible() = true, want false when line end is clipped")
 	}
 }
 
@@ -2211,6 +2279,9 @@ func TestStatusLineFormatterOverridesBuiltInStatusText(t *testing.T) {
 			StatusLine: func(info StatusInfo) (left, right string) {
 				if info.DefaultRight == "" {
 					t.Fatalf("StatusLine got empty right default: %+v", info)
+				}
+				if info.EOFVisible {
+					t.Fatalf("StatusLine EOFVisible = true, want false")
 				}
 				return "L:" + info.DefaultLeft, "R:" + info.DefaultRight
 			},
@@ -2883,7 +2954,7 @@ func TestDrawLineNumbersUsesAdaptiveGutterWidth(t *testing.T) {
 	}
 }
 
-func TestDrawLineNumbersUseSqueezedViewNumbering(t *testing.T) {
+func TestDrawLineNumbersUseSourceNumberingWhenSqueezed(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\n\n\nthree\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -2907,8 +2978,8 @@ func TestDrawLineNumbersUseSqueezedViewNumbering(t *testing.T) {
 	if got := cellRune(screen, 0, 1); got != '2' {
 		t.Fatalf("squeezed blank line number rune = %q, want %q", got, '2')
 	}
-	if got := cellRune(screen, 0, 2); got != '3' {
-		t.Fatalf("third line number rune = %q, want %q", got, '3')
+	if got := cellRune(screen, 0, 2); got != '4' {
+		t.Fatalf("third line number rune = %q, want %q", got, '4')
 	}
 }
 

--- a/pager.go
+++ b/pager.go
@@ -79,17 +79,17 @@ type CommandResult struct {
 	KeepPrompt bool
 }
 
-// Position summarizes the current visible pager viewport.
-// Row and Column are 1-based visible coordinates when content is present, so
-// (1, 1) is the top-left corner of the current viewport. An empty viewport
-// reports Row=0 and Column=0.
+// Position summarizes the current logical pager viewport.
+// Row and Column are 1-based logical coordinates when content is present, so
+// (1, 1) is the start of the first logical line. An empty viewport reports
+// Row=0 and Column=0.
 type Position struct {
 	Row int
-	// Rows is the total visible row count.
+	// Rows is the total logical line count.
 	Rows int
-	// Column is the 1-based visible column number, or 0 when no content is visible.
+	// Column is the 1-based logical display column number, or 0 when no content is visible.
 	Column int
-	// Columns is the maximum visible content width in columns.
+	// Columns is the maximum logical content width in columns.
 	Columns int
 }
 
@@ -463,14 +463,13 @@ func (p *Pager) ClearSearch() {
 	p.viewer.ClearSearch()
 }
 
-// JumpToLine moves the viewport to the requested visible line number.
+// JumpToLine moves the viewport to the requested logical line number.
 func (p *Pager) JumpToLine(lineNumber int) bool {
 	return p.viewer.JumpToLine(lineNumber)
 }
 
-// Position reports the current visible row, total row count, current visible
-// column number, and maximum column span. Row and Column are 1-based when
-// content is present, so (1, 1) is the top-left visible position.
+// Position reports the current logical line, total logical line count,
+// current logical column number, and maximum logical column span.
 func (p *Pager) Position() Position {
 	pos := p.viewer.Position()
 	return Position{
@@ -722,6 +721,9 @@ func toInternalText(text Text) iview.Text {
 	if text.FollowMode == "" {
 		text.FollowMode = defaults.FollowMode
 	}
+	if text.StatusEOF == "" {
+		text.StatusEOF = defaults.StatusEOF
+	}
 	if text.SearchEmpty == "" {
 		text.SearchEmpty = defaults.SearchEmpty
 	}
@@ -762,6 +764,7 @@ func toInternalText(text Text) iview.Text {
 		StatusHelpHint:         text.StatusHelpHint,
 		HideStatusHelpHint:     text.HideStatusHelpHint,
 		FollowMode:             text.FollowMode,
+		StatusEOF:              text.StatusEOF,
 		SearchEmpty:            text.SearchEmpty,
 		SearchNotFound:         text.SearchNotFound,
 		SearchMatchCount:       text.SearchMatchCount,
@@ -778,6 +781,7 @@ func toInternalText(text Text) iview.Text {
 			return text.StatusLine(StatusInfo{
 				Search:       toPublicSearchState(info.Search),
 				Following:    info.Following,
+				EOFVisible:   info.EOFVisible,
 				Message:      info.Message,
 				Position:     Position{Row: info.Position.Row, Rows: info.Position.Rows, Column: info.Position.Column, Columns: info.Position.Columns},
 				DefaultLeft:  info.DefaultLeft,

--- a/pager_test.go
+++ b/pager_test.go
@@ -578,7 +578,7 @@ func TestPagerSearchMethods(t *testing.T) {
 
 func TestPagerWrapModeAndPosition(t *testing.T) {
 	pager := New(Config{TabWidth: 4, WrapMode: NoWrap, ShowStatus: true})
-	pager.SetSize(5, 4)
+	pager.SetSize(5, 2)
 	if err := pager.AppendString("abcdefghij\n"); err != nil {
 		t.Fatalf("AppendString failed: %v", err)
 	}
@@ -606,6 +606,13 @@ func TestPagerWrapModeAndPosition(t *testing.T) {
 	if got, want := pager.Position().Columns, 10; got != want {
 		t.Fatalf("Position().Columns after SoftWrap = %d, want %d", got, want)
 	}
+	pager.ScrollDown(1)
+	if got, want := pager.Position().Row, 1; got != want {
+		t.Fatalf("Position().Row on wrapped continuation = %d, want %d", got, want)
+	}
+	if got, want := pager.Position().Column, 6; got != want {
+		t.Fatalf("Position().Column on wrapped continuation = %d, want %d", got, want)
+	}
 }
 
 func TestPagerJumpToLine(t *testing.T) {
@@ -624,6 +631,28 @@ func TestPagerJumpToLine(t *testing.T) {
 	}
 	if pager.JumpToLine(4) {
 		t.Fatal("JumpToLine(4) = true, want false")
+	}
+}
+
+func TestPagerJumpToLineUsesLogicalLinesInWrap(t *testing.T) {
+	pager := New(Config{TabWidth: 4, WrapMode: SoftWrap, ShowStatus: true})
+	pager.SetSize(4, 2)
+	if err := pager.AppendString("abcdef\nsecond\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	if got, want := pager.Position().Rows, 2; got != want {
+		t.Fatalf("Position().Rows = %d, want %d", got, want)
+	}
+	if !pager.JumpToLine(2) {
+		t.Fatal("JumpToLine(2) = false, want true")
+	}
+	if got, want := pager.Position().Row, 2; got != want {
+		t.Fatalf("Position().Row after wrapped JumpToLine = %d, want %d", got, want)
+	}
+	if pager.JumpToLine(3) {
+		t.Fatal("JumpToLine(3) = true, want false")
 	}
 }
 
@@ -776,7 +805,7 @@ func TestPagerHeaderColumns(t *testing.T) {
 	}
 }
 
-func TestPagerJumpToLineUsesSqueezedView(t *testing.T) {
+func TestPagerJumpToLineUsesSourceLinesWhenSqueezed(t *testing.T) {
 	pager := New(Config{
 		TabWidth:          4,
 		WrapMode:          NoWrap,
@@ -789,10 +818,10 @@ func TestPagerJumpToLineUsesSqueezedView(t *testing.T) {
 	}
 	pager.Flush()
 
-	if !pager.JumpToLine(3) {
-		t.Fatal("JumpToLine(3) = false, want true")
+	if !pager.JumpToLine(4) {
+		t.Fatal("JumpToLine(4) = false, want true")
 	}
-	if got, want := pager.Position().Row, 3; got != want {
+	if got, want := pager.Position().Row, 4; got != want {
 		t.Fatalf("Position().Row after squeezed JumpToLine = %d, want %d", got, want)
 	}
 }

--- a/text.go
+++ b/text.go
@@ -22,7 +22,7 @@ type Text struct {
 	// StatusSearchInfo formats the left-side status text for an active search.
 	StatusSearchInfo func(query string, current, total int) string
 	// StatusPosition formats the right-side position text in the status bar.
-	// current and column are 1-based visible coordinates.
+	// current and column are 1-based logical coordinates.
 	StatusPosition func(current, total, column, columns int) string
 	// StatusHelpHint is shown on the left side of the status bar when no other status text is active.
 	StatusHelpHint string
@@ -30,6 +30,8 @@ type Text struct {
 	HideStatusHelpHint bool
 	// FollowMode is appended to the status bar while follow mode is active.
 	FollowMode string
+	// StatusEOF is appended to the built-in status bar when EOF is visible.
+	StatusEOF string
 	// StatusLine can override the full left and right status bar text.
 	// When nil, the pager assembles the built-in status line from the fields above.
 	StatusLine func(StatusInfo) (left, right string)
@@ -75,6 +77,7 @@ func DefaultText() Text {
 		},
 		StatusHelpHint: "F1 Help",
 		FollowMode:     "follow",
+		StatusEOF:      "EOF",
 		SearchEmpty:    "empty search",
 		SearchNotFound: func(query string) string {
 			return fmt.Sprintf("%s not found", query)

--- a/ui.go
+++ b/ui.go
@@ -9,10 +9,12 @@ type StatusInfo struct {
 	Search SearchState
 	// Following reports whether follow mode is active.
 	Following bool
+	// EOFVisible reports whether the end of the document is currently visible.
+	EOFVisible bool
 	// Message is the current status message appended by pager actions.
 	Message string
-	// Position is the current viewport position. Row and Column are 1-based when
-	// content is present, and 0 when no content is visible.
+	// Position is the current logical viewport position. Row and Column are
+	// 1-based when content is present, and 0 when no content is visible.
 	Position Position
 	// DefaultLeft is the built-in left status text.
 	DefaultLeft string


### PR DESCRIPTION
Fixes #66

## Summary
- make `Position()` report logical line and column coordinates instead of visual wrapped rows
- keep `JumpToLine` and `:n` source-logical, including when squeeze is enabled
- make the gutter and built-in status bar use the same logical numbering scheme
- append `EOF` in the built-in status bar when the end of the document is actually visible
- tighten `EOFVisible()` so a horizontally clipped last line does not count as EOF-visible

## Testing
- `go test ./...`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added EOF indicator to status bar display when end of document is visible.

* **Changes**
  * Position reporting now uses logical line/column coordinates instead of visible viewport coordinates.
  * JumpToLine command now navigates by logical line numbers.
  * Status bar enhanced to display logical row/column numbers and EOF indicator when visible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->