### PR TITLE
Fix FileSource size from current offset

### DIFF
--- a/internal/model/source.go
+++ b/internal/model/source.go
@@ -95,16 +95,31 @@ func (s *StringSource) Size() (int64, bool) {
 
 // FileSource adapts an os.File into a Source.
 type FileSource struct {
-	file *os.File
+	file        *os.File
+	startOffset int64
+	hasOffset   bool
 }
 
 // NewFileSource constructs a Source for an os.File.
+// It snapshots the file's current offset so Fill and Size describe the same
+// readable region for the lifetime of the source.
 func NewFileSource(file *os.File) Source {
-	return &FileSource{file: file}
+	source := &FileSource{file: file}
+	if offset, err := file.Seek(0, io.SeekCurrent); err == nil {
+		source.startOffset = offset
+		source.hasOffset = true
+	}
+	return source
 }
 
-// Fill appends all bytes read from the file's current position to the store.
+// Fill appends all bytes read from the file's captured starting position to the
+// store.
 func (s *FileSource) Fill(store ByteStore) error {
+	if s.hasOffset {
+		if _, err := s.file.Seek(s.startOffset, io.SeekStart); err != nil {
+			return err
+		}
+	}
 	buf := make([]byte, defaultChunkSize)
 	for {
 		n, err := s.file.Read(buf)
@@ -120,11 +135,19 @@ func (s *FileSource) Fill(store ByteStore) error {
 	}
 }
 
-// Size reports the file size when it can be determined.
+// Size reports the remaining file size from the captured starting position when
+// it can be determined.
 func (s *FileSource) Size() (int64, bool) {
+	if !s.hasOffset {
+		return 0, false
+	}
 	info, err := s.file.Stat()
 	if err != nil {
 		return 0, false
 	}
-	return info.Size(), true
+	size := info.Size() - s.startOffset
+	if size < 0 {
+		size = 0
+	}
+	return size, true
 }

--- a/internal/model/source_test.go
+++ b/internal/model/source_test.go
@@ -9,6 +9,16 @@ import (
 	"testing"
 )
 
+func readStore(t *testing.T, store ByteStore) string {
+	t.Helper()
+
+	buf := make([]byte, store.Len())
+	if _, err := store.ReadAt(buf, 0); err != nil {
+		t.Fatalf("ReadAt failed: %v", err)
+	}
+	return string(buf)
+}
+
 func TestBytesSourceFill(t *testing.T) {
 	source := NewBytesSource([]byte("hello"))
 	store := NewChunkStore(4)
@@ -56,5 +66,62 @@ func TestFileSourceSize(t *testing.T) {
 	source := NewFileSource(file)
 	if got, ok := source.Size(); !ok || got != 6 {
 		t.Fatalf("Size = (%d, %v), want (6, true)", got, ok)
+	}
+}
+
+func TestFileSourceSizeFromSeekedOffset(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "goless-*")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+
+	if _, err := file.WriteString("abcdef"); err != nil {
+		t.Fatalf("WriteString failed: %v", err)
+	}
+	if _, err := file.Seek(2, 0); err != nil {
+		t.Fatalf("Seek failed: %v", err)
+	}
+
+	source := NewFileSource(file)
+	if got, ok := source.Size(); !ok || got != 4 {
+		t.Fatalf("Size = (%d, %v), want (4, true)", got, ok)
+	}
+
+	store := NewChunkStore(4)
+	if err := source.Fill(store); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+	if got := readStore(t, store); got != "cdef" {
+		t.Fatalf("Fill data = %q, want %q", got, "cdef")
+	}
+}
+
+func TestFileSourceFillUsesCapturedOffset(t *testing.T) {
+	file, err := os.CreateTemp(t.TempDir(), "goless-*")
+	if err != nil {
+		t.Fatalf("CreateTemp failed: %v", err)
+	}
+	t.Cleanup(func() { _ = file.Close() })
+
+	if _, err := file.WriteString("abcdef"); err != nil {
+		t.Fatalf("WriteString failed: %v", err)
+	}
+	if _, err := file.Seek(3, 0); err != nil {
+		t.Fatalf("Seek failed: %v", err)
+	}
+
+	source := NewFileSource(file)
+
+	if _, err := file.Seek(0, 0); err != nil {
+		t.Fatalf("Seek failed: %v", err)
+	}
+
+	store := NewChunkStore(4)
+	if err := source.Fill(store); err != nil {
+		t.Fatalf("Fill failed: %v", err)
+	}
+	if got := readStore(t, store); got != "def" {
+		t.Fatalf("Fill data = %q, want %q", got, "def")
 	}
 }


### PR DESCRIPTION
## Summary
- snapshot the file offset when `NewFileSource` is created
- report `FileSource.Size()` relative to that captured offset
- add regression tests for seeked files and for consistent `Fill()` behavior

## Testing
- go test ./...

Closes #44.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed file reading behavior to correctly capture and preserve the starting file position at initialization, ensuring reads proceed from the intended location rather than the file's current position at read time.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->