### PR TITLE
Prevent stdin "-" from being specified more than once.

### DIFF
--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -707,6 +707,15 @@ func programInputs(args []string) (programStartup, []string, error) {
 		}
 	}
 	files := append([]string(nil), positional...)
+	stdinCount := 0
+	for _, path := range files {
+		if isProgramStdinInput(path) {
+			stdinCount++
+		}
+	}
+	if stdinCount > 1 {
+		return programStartup{}, nil, fmt.Errorf("stdin may be specified at most once")
+	}
 	if len(files) == 1 && isProgramStdinInput(files[0]) {
 		files = nil
 	}

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -628,6 +628,9 @@ func TestDemoInputs(t *testing.T) {
 		{name: "startup with separator", args: []string{"+7", "--", "sample.txt"}, wantLine: 7, wantFiles: []string{"sample.txt"}},
 		{name: "separator only", args: []string{"--", "sample.txt"}, wantFiles: []string{"sample.txt"}},
 		{name: "separator stdin", args: []string{"--", "-"}},
+		{name: "duplicate explicit stdin", args: []string{"-", "-"}, wantErr: true},
+		{name: "duplicate explicit stdin among files", args: []string{"a.txt", "-", "b.txt", "-"}, wantErr: true},
+		{name: "duplicate explicit stdin with startup", args: []string{"+42", "--", "-", "sample.txt", "-"}, wantErr: true},
 		{name: "bad startup", args: []string{"+bogus"}, wantErr: true},
 		{name: "bad startup search", args: []string{"+/"}, wantErr: true},
 	}


### PR DESCRIPTION
Fixes #65  (well sort of)

There is a lot of complexity for supporting "-" more than once, and no really good use case for it, so we're simply erroring out if a user tries to do it.