### PR TITLE
Ensure active match is highlighted at highest priority.

### DIFF
--- a/internal/view/search.go
+++ b/internal/view/search.go
@@ -829,6 +829,7 @@ func (v *Viewer) graphemeMatched(line model.Line, lineIndex int, grapheme model.
 	if len(search.Matches) == 0 {
 		return false, false
 	}
+	matched := false
 	for i, match := range search.Matches {
 		if match.LineIndex != lineIndex {
 			continue
@@ -836,9 +837,12 @@ func (v *Viewer) graphemeMatched(line model.Line, lineIndex int, grapheme model.
 		if grapheme.RuneStart >= match.EndRune || grapheme.RuneEnd <= match.StartRune {
 			continue
 		}
-		return true, i == search.Current
+		matched = true
+		if i == search.Current {
+			return true, true
+		}
 	}
-	return false, false
+	return matched, false
 }
 
 func (v *Viewer) pickInitialPreviewMatch(search *searchState) int {

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -1650,6 +1650,39 @@ func TestApplyMatchCellStyleUsesUnderlineAccents(t *testing.T) {
 	}
 }
 
+func TestDrawPrefersActiveStyleForOverlappingSearchMatches(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("ababa\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap})
+	v.SetSize(8, 2)
+
+	if !v.SearchForward("aba") {
+		t.Fatal("SearchForward returned false, want true")
+	}
+	if !v.SearchNext() {
+		t.Fatal("SearchNext returned false, want true")
+	}
+
+	_, screen := newMockScreen(t, 8, 2)
+	defer screen.Fini()
+
+	v.Draw(screen)
+
+	_, overlapStyle, _ := screen.Get(2, 0)
+	if got, want := overlapStyle.GetBackground(), currentMatchStyle.Bg; got != want {
+		t.Fatalf("overlap background = %v, want %v", got, want)
+	}
+	if !overlapStyle.HasBold() {
+		t.Fatal("overlap style should use active match bold")
+	}
+	if got, want := overlapStyle.GetUnderlineStyle(), currentMatchStyle.UnderlineStyle; got != want {
+		t.Fatalf("overlap underline style = %v, want %v", got, want)
+	}
+}
+
 func TestRefreshPicksUpAppendedDocumentContent(t *testing.T) {
 	doc := model.NewDocument(4)
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})


### PR DESCRIPTION
Fixes #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed rendering of overlapping search matches to correctly display the active match highlighting, ensuring the current match style is preferred over inactive match styles.

* **Tests**
  * Added test coverage to validate overlapping search match rendering behavior with proper style application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->