### PR TITLE
Add :license and --license to show license details (fixes #90)

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,7 @@ Program flags:
 - `-S` accepted as a less-compatibility no-op because no-wrap is already the default
 - `-i` for smart-case search behavior
 - `-I` for case-insensitive search behavior
+- `--license` to open the bundled Apache license, or print it when stdout is not a terminal
 - `-x n` to set tab width
 - `-preset dark|light|plain|pretty`
 - `-chrome auto|none|single|rounded`
@@ -364,6 +365,7 @@ The default key group is intentionally less-like. Common bindings include:
 - `:50%` to jump near the middle of the document
 - `:next` / `:prev` to move through a multi-file session
 - `:first`, `:last`, `:x`, and `:file` for file-session control
+- `:license` to show the bundled Apache license in an overlay
 - `:Q` as an additional quit command
 - `=` or `Ctrl-G` to show current file/session status in the standalone program
 - `:set number`, `:set wrap`, `:set list`, and `:set squeeze` plus `no...` and `inv...` forms

--- a/cmd/goless/help.txt
+++ b/cmd/goless/help.txt
@@ -52,3 +52,4 @@
   :set ignorecase         search without case sensitivity
   :set smartcase          search smart-case
   :set searchmode=[3mmode[0m    set match mode (sub|word|regex)
+  :license                show the bundled Apache license

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -45,6 +45,7 @@ type programOptions struct {
 	renderName        string
 	searchCaseMode    goless.SearchCaseMode
 	showHelp          bool
+	showLicense       bool
 	squeeze           bool
 	tabWidth          int
 	title             string
@@ -97,10 +98,14 @@ func run() error {
 		return err
 	}
 	if !stdoutIsTerminal() {
+		if opts.showLicense {
+			_, err := io.WriteString(os.Stdout, goless.LicenseText())
+			return err
+		}
 		return passThroughProgramInputs(os.Stdout, os.Stdin, files)
 	}
 
-	if stdinIsTerminal() && (!session.hasFiles() || programInputsUseStdin(files)) {
+	if stdinIsTerminal() && programRequiresInput(opts, files) {
 		return fmt.Errorf("stdin is a terminal; specify a file or pipe input")
 	}
 
@@ -137,16 +142,27 @@ func run() error {
 			opts.searchCaseMode,
 			opts.squeeze,
 			opts.tabWidth,
-			session.commandHandler(func() error {
-				if reloadCurrent == nil {
-					return fmt.Errorf("file reload unavailable")
-				}
-				_, err := reloadCurrent()
-				return err
-			}),
+			session.commandHandler(
+				func() error {
+					if reloadCurrent == nil {
+						return fmt.Errorf("file reload unavailable")
+					}
+					_, err := reloadCurrent()
+					return err
+				},
+				func(title, body string) {
+					if pager != nil {
+						pager.ShowInformation(title, body)
+					}
+				},
+			),
 		)
 	}
-	if session.hasFiles() {
+	if opts.showLicense {
+		pager = buildProgramPager()
+		pager.SetSize(width, height)
+		pager.ShowInformation("Apache License 2.0", goless.LicenseText())
+	} else if session.hasFiles() {
 		reloadCurrent = func() (bool, error) {
 			loaded, snapshot, err := reloadProgramInput(session, inputLoader, &pager, buildProgramPager, width, height, screen.EventQ(), &readResult)
 			if err == nil {
@@ -163,21 +179,23 @@ func run() error {
 		readResult = startProgramRead(pager, os.Stdin, screen.EventQ(), nil)
 	}
 	pager.Draw(screen)
-	quit, err := handleProgramQuitIfOneScreen(quitIfOneScreenArmed, session, func() programViewportSnapshot { return pagerSnapshot }, readResult == nil, reloadCurrent)
-	if err != nil {
-		return err
-	}
-	pager.Draw(screen)
-	if quit {
-		return programExit(screen, quitAtEOFPolicy)
-	}
-	quit, err = handleProgramVisibleEOF(quitAtEOFPolicy, session, func() *goless.Pager { return pager }, readResult == nil, reloadCurrent)
-	if err != nil {
-		return err
-	}
-	pager.Draw(screen)
-	if quit {
-		return programExit(screen, quitAtEOFPolicy)
+	if !opts.showLicense {
+		quit, err := handleProgramQuitIfOneScreen(quitIfOneScreenArmed, session, func() programViewportSnapshot { return pagerSnapshot }, readResult == nil, reloadCurrent)
+		if err != nil {
+			return err
+		}
+		pager.Draw(screen)
+		if quit {
+			return programExit(screen, quitAtEOFPolicy)
+		}
+		quit, err = handleProgramVisibleEOF(quitAtEOFPolicy, session, func() *goless.Pager { return pager }, readResult == nil, reloadCurrent)
+		if err != nil {
+			return err
+		}
+		pager.Draw(screen)
+		if quit {
+			return programExit(screen, quitAtEOFPolicy)
+		}
 	}
 
 	for {
@@ -209,6 +227,7 @@ func run() error {
 			}
 			before := pager.Position()
 			beforeFollowing := pager.Following()
+			wasShowingInformation := pager.ShowingInformation()
 			result := pager.HandleKeyResult(event)
 			if shouldHandleProgramStatusKey(result) && handleProgramStatusKey(pager, event) {
 				pager.Draw(screen)
@@ -217,13 +236,18 @@ func run() error {
 			if result.Quit {
 				return programExit(screen, quitAtEOFPolicy)
 			}
-			quit, err := handleProgramVisibleEOFAction(quitAtEOFPolicy, session, func() *goless.Pager { return pager }, result, readResult == nil, reloadCurrent)
-			if err != nil {
-				return err
-			}
-			pager.Draw(screen)
-			if quit {
+			if programShouldQuitAfterOverlayClose(session, pager, wasShowingInformation, result) {
 				return programExit(screen, quitAtEOFPolicy)
+			}
+			if !opts.showLicense {
+				quit, err := handleProgramVisibleEOFAction(quitAtEOFPolicy, session, func() *goless.Pager { return pager }, result, readResult == nil, reloadCurrent)
+				if err != nil {
+					return err
+				}
+				pager.Draw(screen)
+				if quit {
+					return programExit(screen, quitAtEOFPolicy)
+				}
 			}
 			if quit, err := applyProgramQuitAtEOF(
 				quitAtEOFPolicy,
@@ -288,12 +312,13 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 	fs := flag.NewFlagSet("goless", flag.ContinueOnError)
 	fs.SetOutput(output)
 	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "usage: goless [-?|-e|-E|-F|-N|-R|-S|-i|-I|-s] [-x n] [-preset dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [+line|+/pattern] [-version] [path ...]\n")
+		fmt.Fprintf(fs.Output(), "usage: goless [-?|-e|-E|-F|-N|-R|-S|-i|-I|-s] [-x n] [-preset dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [-license] [+line|+/pattern] [-version] [path ...]\n")
 	}
 
 	fs.BoolVar(&opts.showHelp, "?", false, "show help")
 	fs.BoolVar(&opts.showHelp, "help", false, "show help")
 	fs.BoolVar(&opts.showHelp, "h", false, "show help")
+	fs.BoolVar(&opts.showLicense, "license", false, "show the bundled Apache license")
 	fs.BoolVar(&opts.quitAtEOF, "e", false, "quit on the first forward command at EOF")
 	fs.BoolVar(&opts.quitAtEOFFirst, "E", false, "quit when EOF is already visible on screen")
 	fs.BoolVar(&opts.quitIfOneScreen, "F", false, "quit if the entire input fits on one screen")
@@ -336,6 +361,14 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 	if opts.tabWidth <= 0 {
 		return programOptions{}, nil, fmt.Errorf("-x must be greater than 0")
 	}
+	if opts.showLicense {
+		if fs.NFlag() > 1 {
+			return programOptions{}, nil, fmt.Errorf("--license must be used alone")
+		}
+		if len(fs.Args()) > 0 {
+			return programOptions{}, nil, fmt.Errorf("--license cannot be combined with files")
+		}
+	}
 	return opts, fs.Args(), nil
 }
 
@@ -347,6 +380,32 @@ func programQuitAtEOFPolicyFromFlags(quitAtEOF, quitAtEOFFirst bool) programQuit
 		return programQuitAtEOFOnForwardEOF
 	}
 	return programQuitAtEOFNever
+}
+
+func programRequiresInput(opts programOptions, files []string) bool {
+	if opts.showLicense {
+		return false
+	}
+	return len(files) == 0 || programInputsUseStdin(files)
+}
+
+func programShouldQuitAfterOverlayClose(session *programSession, pager *goless.Pager, wasShowingInformation bool, result goless.KeyResult) bool {
+	if pager == nil {
+		return false
+	}
+	if result.Context != goless.HelpKeyContext || result.Action != goless.KeyActionToggleHelp {
+		return false
+	}
+	if !wasShowingInformation {
+		return false
+	}
+	if pager.ShowingInformation() {
+		return false
+	}
+	if session != nil && session.hasFiles() {
+		return false
+	}
+	return pager.Len() == 0
 }
 
 func programExit(screen tcell.Screen, policy programQuitAtEOFPolicy) error {
@@ -776,13 +835,18 @@ func (s *programSession) last() bool {
 	return true
 }
 
-func (s *programSession) commandHandler(reload func() error) func(goless.Command) goless.CommandResult {
+func (s *programSession) commandHandler(reload func() error, showInformation func(title, body string)) func(goless.Command) goless.CommandResult {
 	return func(cmd goless.Command) goless.CommandResult {
 		switch cmd.Name {
 		case "q", "Q", "quit":
 			return goless.CommandResult{Handled: true, Quit: true}
 		case "file", "f":
 			return goless.CommandResult{Handled: true, Message: s.currentFileLabel()}
+		case "license":
+			if showInformation != nil {
+				showInformation("Apache License 2.0", goless.LicenseText())
+			}
+			return goless.CommandResult{Handled: true}
 		case "version":
 			return goless.CommandResult{Handled: true, Message: version()}
 		case "next", "n":

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -582,6 +582,128 @@ func TestParseProgramFlagsHelp(t *testing.T) {
 	}
 }
 
+func TestParseProgramFlagsLicense(t *testing.T) {
+	var out bytes.Buffer
+	opts, args, err := parseProgramFlags([]string{"--license"}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(--license) failed: %v", err)
+	}
+	if !opts.showLicense {
+		t.Fatal("parseProgramFlags(--license) did not set showLicense")
+	}
+	if len(args) != 0 {
+		t.Fatalf("len(args) after --license = %d, want 0", len(args))
+	}
+}
+
+func TestParseProgramFlagsLicenseExclusive(t *testing.T) {
+	var out bytes.Buffer
+	_, _, err := parseProgramFlags([]string{"--license", "-N"}, &out)
+	if err == nil {
+		t.Fatal("parseProgramFlags(--license -N) = nil error, want error")
+	}
+	out.Reset()
+	if _, _, err := parseProgramFlags([]string{"--license", "file.txt"}, &out); err == nil {
+		t.Fatal("parseProgramFlags(--license file.txt) = nil error, want error")
+	}
+}
+
+func TestProgramRequiresInput(t *testing.T) {
+	tests := []struct {
+		name  string
+		opts  programOptions
+		files []string
+		want  bool
+	}{
+		{name: "license without files", opts: programOptions{showLicense: true}, want: false},
+		{name: "license with stdin file", opts: programOptions{showLicense: true}, files: []string{"-"}, want: false},
+		{name: "no files", opts: programOptions{}, want: true},
+		{name: "stdin file", opts: programOptions{}, files: []string{"sample.txt", "-"}, want: true},
+		{name: "real file", opts: programOptions{}, files: []string{"sample.txt"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := programRequiresInput(tt.opts, tt.files); got != tt.want {
+				t.Fatalf("programRequiresInput(%+v, %v) = %v, want %v", tt.opts, tt.files, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProgramShouldQuitAfterOverlayClose(t *testing.T) {
+	tests := []struct {
+		name          string
+		withFiles     bool
+		content       string
+		result        goless.KeyResult
+		overlay       bool
+		remainOverlay bool
+		want          bool
+	}{
+		{
+			name:          "license only close exits",
+			result:        goless.KeyResult{Handled: true, Context: goless.HelpKeyContext, Action: goless.KeyActionToggleHelp},
+			overlay:       true,
+			remainOverlay: false,
+			want:          true,
+		},
+		{
+			name:          "still showing overlay does not exit",
+			result:        goless.KeyResult{Handled: true, Context: goless.HelpKeyContext, Action: goless.KeyActionToggleHelp},
+			overlay:       true,
+			remainOverlay: true,
+			want:          false,
+		},
+		{
+			name:      "open files do not exit",
+			withFiles: true,
+			result:    goless.KeyResult{Handled: true, Context: goless.HelpKeyContext, Action: goless.KeyActionToggleHelp},
+			want:      false,
+		},
+		{
+			name:    "document content does not exit",
+			content: "alpha\n",
+			result:  goless.KeyResult{Handled: true, Context: goless.HelpKeyContext, Action: goless.KeyActionToggleHelp},
+			want:    false,
+		},
+		{
+			name:   "non-toggle action does not exit",
+			result: goless.KeyResult{Handled: true, Context: goless.HelpKeyContext, Action: goless.KeyActionRefresh},
+			want:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var files []string
+			if tt.withFiles {
+				files = []string{"sample.txt"}
+			}
+			session := newProgramSession(files, programStartup{})
+			pager := goless.New(goless.Config{TabWidth: 4, WrapMode: goless.NoWrap, ShowStatus: true})
+			pager.SetSize(20, 4)
+			if tt.content != "" {
+				if err := pager.AppendString(tt.content); err != nil {
+					t.Fatalf("AppendString failed: %v", err)
+				}
+				pager.Flush()
+			}
+			if tt.overlay {
+				pager.ShowInformation("License", "Apache License")
+			}
+			wasShowing := pager.ShowingInformation()
+			if tt.overlay && !tt.remainOverlay {
+				pager.HideInformation()
+			}
+
+			if got := programShouldQuitAfterOverlayClose(session, pager, wasShowing, tt.result); got != tt.want {
+				t.Fatalf("programShouldQuitAfterOverlayClose(...) = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestNewDemoPagerPropagatesConfig(t *testing.T) {
 	pager := newProgramPager(
 		goless.RenderHybrid,
@@ -613,7 +735,7 @@ func TestDemoSessionCommandHandler(t *testing.T) {
 	handler := session.commandHandler(func() error {
 		reloads++
 		return nil
-	})
+	}, nil)
 
 	if result := handler(goless.Command{Name: "quit"}); !result.Handled || !result.Quit {
 		t.Fatalf("quit command result = %+v, want handled quit", result)
@@ -673,7 +795,7 @@ func TestDemoSessionAdditionalCommands(t *testing.T) {
 	handler := session.commandHandler(func() error {
 		reloads++
 		return nil
-	})
+	}, nil)
 
 	result := handler(goless.Command{Name: "file"})
 	if !result.Handled || result.Quit {
@@ -722,6 +844,38 @@ func TestDemoSessionAdditionalCommands(t *testing.T) {
 	}
 	if got, want := reloads, 2; got != want {
 		t.Fatalf("reload count after x = %d, want %d", got, want)
+	}
+}
+
+func TestDemoSessionLicenseCommandShowsBundledLicense(t *testing.T) {
+	session := newProgramSession([]string{"one.txt"}, programStartup{})
+	var (
+		title string
+		body  string
+	)
+	handler := session.commandHandler(func() error {
+		t.Fatal("reload should not be called for :license")
+		return nil
+	}, func(gotTitle, gotBody string) {
+		title = gotTitle
+		body = gotBody
+	})
+
+	result := handler(goless.Command{Name: "license"})
+	if !result.Handled || result.Quit {
+		t.Fatalf("license command result = %+v, want handled non-quit", result)
+	}
+	if got, want := result.Message, ""; got != want {
+		t.Fatalf("license command message = %q, want empty", got)
+	}
+	if got, want := title, "Apache License 2.0"; got != want {
+		t.Fatalf("license title = %q, want %q", got, want)
+	}
+	if !strings.Contains(body, "Apache License") {
+		t.Fatalf("license body missing Apache heading: %q", body)
+	}
+	if !strings.Contains(body, "Version 2.0, January 2004") {
+		t.Fatalf("license body missing version heading: %q", body)
 	}
 }
 
@@ -830,7 +984,7 @@ func TestDemoSessionLabelsExplicitStdin(t *testing.T) {
 	handler := session.commandHandler(func() error {
 		reloads++
 		return nil
-	})
+	}, nil)
 
 	result := handler(goless.Command{Name: "next"})
 	if !result.Handled || result.Quit {
@@ -856,7 +1010,7 @@ func TestDemoSessionCommandHandlerBlocksNavigationWhileStdinReading(t *testing.T
 	session := newProgramSession([]string{"one.txt", "-"}, programStartup{})
 	handler := session.commandHandler(func() error {
 		return fmt.Errorf("stdin still reading")
-	})
+	}, nil)
 
 	result := handler(goless.Command{Name: "next"})
 	if !result.Handled || result.Quit {
@@ -874,7 +1028,7 @@ func TestDemoSessionCommandHandlerReloadFailureRestoresIndex(t *testing.T) {
 	session := newProgramSession([]string{"one.txt", "two.txt"}, programStartup{})
 	handler := session.commandHandler(func() error {
 		return fmt.Errorf("reload failed")
-	})
+	}, nil)
 
 	result := handler(goless.Command{Name: "next"})
 	if !result.Handled || result.Quit {
@@ -892,7 +1046,7 @@ func TestDemoSessionCommandHandlerReloadFailureRestoresIndexForLast(t *testing.T
 	session := newProgramSession([]string{"one.txt", "two.txt", "three.txt"}, programStartup{})
 	handler := session.commandHandler(func() error {
 		return fmt.Errorf("reload failed")
-	})
+	}, nil)
 
 	result := handler(goless.Command{Name: "last"})
 	if !result.Handled || result.Quit {

--- a/internal/view/help.go
+++ b/internal/view/help.go
@@ -15,7 +15,10 @@ func (v *Viewer) drawHelp(screen tcell.Screen) {
 	bodyStyle := v.toTCellStyle(ansi.DefaultStyle())
 	if !v.cfg.Chrome.Frame.enabled() && v.width > 0 {
 		titleStyle := tcell.StyleDefault.Reverse(true)
-		title := " " + v.text.HelpTitle + "  " + v.text.HelpClose
+		title := " " + v.informationTitle()
+		if v.text.HelpClose != "" {
+			title += "  " + v.text.HelpClose
+		}
 		screen.PutStrStyled(0, 0, padRightToWidth(title, v.width), titleStyle)
 	}
 
@@ -80,7 +83,7 @@ func (v *Viewer) clampHelpOffset() {
 
 func (v *Viewer) helpLines() []model.Line {
 	doc := model.NewDocumentWithMode(helpDocChunkSize, ansi.RenderPresentation)
-	_ = doc.Append([]byte(v.text.HelpBody))
+	_ = doc.Append([]byte(v.informationBody()))
 	doc.Flush()
 	return doc.Lines()
 }

--- a/internal/view/input.go
+++ b/internal/view/input.go
@@ -11,6 +11,11 @@ const (
 	modeHelp
 )
 
+type informationOverlay struct {
+	title string
+	body  string
+}
+
 type promptKind int
 
 const (

--- a/internal/view/search.go
+++ b/internal/view/search.go
@@ -273,7 +273,9 @@ func (v *Viewer) beginPrompt(kind promptKind) {
 }
 
 func (v *Viewer) cancelPrompt() {
-	v.mode = modeNormal
+	if v.mode == modePrompt {
+		v.mode = modeNormal
+	}
 	v.prompt = nil
 }
 

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -59,6 +59,7 @@ type Viewer struct {
 	rowOffset     int
 	colOffset     int
 	follow        bool
+	overlay       *informationOverlay
 	helpOffset    int
 	helpColOffset int
 }
@@ -271,6 +272,27 @@ func (v *Viewer) SetShowStatus(enabled bool) {
 		return
 	}
 	v.restoreAnchor(anchor)
+}
+
+// ShowInformation replaces the document view with a scrollable information overlay.
+func (v *Viewer) ShowInformation(title, body string) {
+	v.overlay = &informationOverlay{
+		title: title,
+		body:  body,
+	}
+	v.mode = modeHelp
+	v.helpOffset = 0
+	v.helpColOffset = 0
+}
+
+// HideInformation closes the current information overlay if one is visible.
+func (v *Viewer) HideInformation() {
+	v.overlay = nil
+}
+
+// ShowingInformation reports whether an information overlay is visible.
+func (v *Viewer) ShowingInformation() bool {
+	return v.overlay != nil
 }
 
 // SetText updates help text, status text, prompt text, and UI strings.
@@ -1887,7 +1909,7 @@ func toPromptKind(kind promptKind) PromptKind {
 }
 
 func (v *Viewer) helpFrameTitle() string {
-	title := v.text.HelpTitle
+	title := v.informationTitle()
 	if v.text.HelpClose != "" {
 		if title != "" {
 			title += "  "
@@ -2144,6 +2166,11 @@ func (v *Viewer) handlePromptMappedAction(a action) (KeyResult, bool) {
 }
 
 func (v *Viewer) toggleHelp() {
+	if v.overlay != nil {
+		v.overlay = nil
+		v.mode = modeNormal
+		return
+	}
 	if v.mode == modeHelp {
 		v.mode = modeNormal
 		return
@@ -2151,6 +2178,20 @@ func (v *Viewer) toggleHelp() {
 	v.mode = modeHelp
 	v.helpOffset = 0
 	v.helpColOffset = 0
+}
+
+func (v *Viewer) informationTitle() string {
+	if v.overlay != nil {
+		return v.overlay.title
+	}
+	return v.text.HelpTitle
+}
+
+func (v *Viewer) informationBody() string {
+	if v.overlay != nil {
+		return v.overlay.body
+	}
+	return v.text.HelpBody
 }
 
 func (v *Viewer) updateFollowAtBottom() {

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -2276,6 +2276,65 @@ func TestDrawHelpAppliesANSIStyles(t *testing.T) {
 	}
 }
 
+func TestShowInformationDisplaysCustomOverlay(t *testing.T) {
+	doc := model.NewDocument(4)
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap})
+	v.SetSize(24, 6)
+	v.ShowInformation("License", "alpha\nbeta")
+
+	if !v.ShowingInformation() {
+		t.Fatal("ShowingInformation() = false, want true")
+	}
+
+	_, screen := newMockScreen(t, 24, 6)
+	defer screen.Fini()
+
+	v.Draw(screen)
+
+	if row := screenRowString(screen, 0, 24); !strings.Contains(row, "License") {
+		t.Fatalf("title row = %q, want it to contain %q", row, "License")
+	}
+	if got, want := strings.TrimRight(screenRowString(screen, 1, 24), " "), "alpha"; got != want {
+		t.Fatalf("first body row = %q, want %q", got, want)
+	}
+}
+
+func TestCommandPromptCanOpenInformationOverlay(t *testing.T) {
+	doc := model.NewDocument(4)
+	var v *Viewer
+	v = New(doc, Config{
+		TabWidth: 4,
+		WrapMode: layout.NoWrap,
+		CommandHandler: func(cmd Command) CommandResult {
+			if cmd.Name != "license" {
+				return CommandResult{}
+			}
+			v.ShowInformation("License", "Apache License")
+			return CommandResult{Handled: true}
+		},
+	})
+	v.SetSize(24, 6)
+	v.beginPrompt(promptCommand)
+	v.prompt.editor.SetText("license")
+
+	result := v.commitPrompt()
+	if !result.Handled || result.Context != KeyContextPrompt {
+		t.Fatalf("commitPrompt() = %+v, want handled prompt result", result)
+	}
+	if got, want := v.mode, modeHelp; got != want {
+		t.Fatalf("mode after :license = %v, want %v", got, want)
+	}
+	if v.prompt != nil {
+		t.Fatal("prompt after :license = non-nil, want nil")
+	}
+	if v.overlay == nil {
+		t.Fatal("overlay after :license = nil, want custom overlay")
+	}
+	if got, want := v.overlay.title, "License"; got != want {
+		t.Fatalf("overlay title = %q, want %q", got, want)
+	}
+}
+
 func TestStatusShowsRightOverflowIndicator(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("abcdefghijklmnopqrstuvwxyz")); err != nil {

--- a/license.go
+++ b/license.go
@@ -1,0 +1,14 @@
+// Copyright 2026 Garrett D'Amore
+// SPDX-License-Identifier: Apache-2.0
+
+package goless
+
+import _ "embed"
+
+//go:embed LICENSE
+var licenseText string
+
+// LicenseText returns the project's bundled Apache License text.
+func LicenseText() string {
+	return licenseText
+}

--- a/pager.go
+++ b/pager.go
@@ -279,6 +279,21 @@ func (p *Pager) SetChrome(chrome Chrome) {
 	p.Configure(WithChrome(chrome))
 }
 
+// ShowInformation replaces the document view with a scrollable information overlay.
+func (p *Pager) ShowInformation(title, body string) {
+	p.viewer.ShowInformation(title, body)
+}
+
+// HideInformation closes the current information overlay if one is visible.
+func (p *Pager) HideInformation() {
+	p.viewer.HideInformation()
+}
+
+// ShowingInformation reports whether an information overlay is visible.
+func (p *Pager) ShowingInformation() bool {
+	return p.viewer.ShowingInformation()
+}
+
 // HandleKey applies a key event and reports whether the caller should exit.
 func (p *Pager) HandleKey(ev *tcell.EventKey) bool {
 	return p.HandleKeyResult(ev).Quit

--- a/pager_test.go
+++ b/pager_test.go
@@ -118,6 +118,38 @@ func TestPagerHandleKeyResultPromptContext(t *testing.T) {
 	}
 }
 
+func TestPagerShowInformation(t *testing.T) {
+	pager := New(Config{TabWidth: 4, WrapMode: NoWrap, ShowStatus: true})
+	pager.SetSize(24, 6)
+	pager.ShowInformation("License", "alpha\nbeta")
+
+	if !pager.ShowingInformation() {
+		t.Fatal("ShowingInformation() = false, want true")
+	}
+
+	screen := newPagerMockScreen(t, 24, 6)
+	defer screen.Fini()
+
+	pager.Draw(screen)
+	if row := pagerRowString(screen, 0, 24); !strings.Contains(row, "License") {
+		t.Fatalf("title row = %q, want it to contain %q", row, "License")
+	}
+	if got, want := strings.TrimRight(pagerRowString(screen, 1, 24), " "), "alpha"; got != want {
+		t.Fatalf("first body row = %q, want %q", got, want)
+	}
+
+	result := pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyF1, "", tcell.ModNone))
+	if !result.Handled {
+		t.Fatal("HandleKeyResult(F1).Handled = false, want true")
+	}
+	if got, want := result.Context, HelpKeyContext; got != want {
+		t.Fatalf("HandleKeyResult(F1).Context = %v, want %v", got, want)
+	}
+	if pager.ShowingInformation() {
+		t.Fatal("ShowingInformation() after F1 = true, want false")
+	}
+}
+
 func TestPagerCaptureKeyReservesBinding(t *testing.T) {
 	pager := New(Config{
 		TabWidth:   4,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `--license` flag to show the bundled Apache License 2.0 (prints to stdout when non-terminal, or opens an interactive overlay in a terminal). The flag is intended for standalone use.
  * Added a `:license` command to open the Apache License 2.0 in an on-screen overlay anytime.

* **Bug Fixes**
  * Improved search prompt cancellation to correctly return to normal viewing mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->