### PR TITLE
feat: Add mouse handling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ func main() {
 		return
 	}
 	defer screen.Fini()
+	screen.EnableMouse()
 
 	pager.Draw(screen)
 	_ = pager.SearchForward("world")
@@ -165,7 +166,8 @@ The normal embedding model is:
    finalized.
 4. Size with `SetSize`.
 5. Render with `Draw`.
-6. Drive interaction through `HandleKey` or direct method calls.
+6. If you want wheel input, call `screen.EnableMouse()`.
+7. Drive interaction through `HandleKey`, `HandleMouse`, or direct method calls.
 
 ## Public API Shape
 
@@ -175,7 +177,7 @@ The current exported `Pager` API is controller-oriented.
 - Runtime reconfiguration: `Configure(opts ...RuntimeOption)`
 - Content loading: `Append`, `AppendString`, `ReadFrom`, `Flush`, `Len`
 - Rendering: `SetSize`, `Draw`, `Refresh`
-- Key-driven integration: `HandleKey`
+- Input integration: `HandleKey`, `HandleMouse`
 - Navigation: `ScrollUp`, `ScrollDown`, `ScrollLeft`, `ScrollRight`, `HalfPageUp`,
   `HalfPageDown`, `PageUp`, `PageDown`, `GoTop`, `GoBottom`, `GoPercent`, `JumpToLine`
 - Mode control: `ToggleWrap`, `SetWrapMode`, `WrapMode`, `Follow`, `Following`

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -57,6 +57,13 @@ type programViewportSnapshot struct {
 	following  bool
 }
 
+type programInputResult struct {
+	handled bool
+	quit    bool
+	action  goless.KeyAction
+	context goless.KeyContext
+}
+
 func main() {
 	if err := run(); err != nil {
 		fmt.Fprintln(os.Stderr, err)
@@ -229,39 +236,37 @@ func run() error {
 			before := pager.Position()
 			beforeFollowing := pager.Following()
 			wasShowingInformation := pager.ShowingInformation()
-			result := pager.HandleKeyResult(event)
-			if shouldHandleProgramStatusKey(result) && handleProgramStatusKey(pager, event) {
+			keyResult := pager.HandleKeyResult(event)
+			if shouldHandleProgramStatusKey(keyResult) && handleProgramStatusKey(pager, event) {
 				pager.Draw(screen)
 				break
 			}
-			if result.Quit {
+			if keyResult.Quit {
 				return programExit(screen, quitAtEOFPolicy)
 			}
-			if programShouldQuitAfterOverlayClose(session, pager, wasShowingInformation, result) {
+			if programShouldQuitAfterOverlayClose(session, pager, wasShowingInformation, keyResult) {
 				return programExit(screen, quitAtEOFPolicy)
 			}
-			if !opts.showLicense {
-				quit, err := handleProgramVisibleEOFAction(quitAtEOFPolicy, session, func() *goless.Pager { return pager }, result, readResult == nil, reloadCurrent)
-				if err != nil {
-					return err
-				}
-				pager.Draw(screen)
-				if quit {
-					return programExit(screen, quitAtEOFPolicy)
-				}
-			}
-			if quit, err := applyProgramQuitAtEOF(
+			quit, err := handleProgramPostInput(
 				quitAtEOFPolicy,
+				opts.showLicense,
 				session,
-				result,
+				pager,
+				programInputResult{
+					handled: keyResult.Handled,
+					quit:    keyResult.Quit,
+					action:  keyResult.Action,
+					context: keyResult.Context,
+				},
 				readResult == nil,
 				beforeFollowing,
 				before,
-				pager.Position(),
 				reloadCurrent,
-			); err != nil {
+			)
+			if err != nil {
 				return err
-			} else if quit {
+			}
+			if quit {
 				return programExit(screen, quitAtEOFPolicy)
 			}
 			if readResult != nil {
@@ -270,35 +275,27 @@ func run() error {
 		case *tcell.EventMouse:
 			before := pager.Position()
 			beforeFollowing := pager.Following()
-			result := pager.HandleMouseResult(event)
-			if !opts.showLicense {
-				keyResult := goless.KeyResult{
-					Handled: result.Handled,
-					Action:  result.Action,
-					Context: result.Context,
-				}
-				quit, err := handleProgramVisibleEOFAction(quitAtEOFPolicy, session, func() *goless.Pager { return pager }, keyResult, readResult == nil, reloadCurrent)
-				if err != nil {
-					return err
-				}
-				pager.Draw(screen)
-				if quit {
-					return programExit(screen, quitAtEOFPolicy)
-				}
-				if quit, err := applyProgramQuitAtEOF(
-					quitAtEOFPolicy,
-					session,
-					keyResult,
-					readResult == nil,
-					beforeFollowing,
-					before,
-					pager.Position(),
-					reloadCurrent,
-				); err != nil {
-					return err
-				} else if quit {
-					return programExit(screen, quitAtEOFPolicy)
-				}
+			mouseResult := pager.HandleMouseResult(event)
+			quit, err := handleProgramPostInput(
+				quitAtEOFPolicy,
+				opts.showLicense,
+				session,
+				pager,
+				programInputResult{
+					handled: mouseResult.Handled,
+					action:  mouseResult.Action,
+					context: mouseResult.Context,
+				},
+				readResult == nil,
+				beforeFollowing,
+				before,
+				reloadCurrent,
+			)
+			if err != nil {
+				return err
+			}
+			if quit {
+				return programExit(screen, quitAtEOFPolicy)
 			}
 			if readResult != nil {
 				quitIfOneScreenArmed = updateProgramQuitIfOneScreenArm(quitIfOneScreenArmed, pager)
@@ -472,6 +469,39 @@ func newProgramScreen(policy programQuitAtEOFPolicy) (tcell.Screen, error) {
 		return tcell.NewTerminfoScreen(tcell.OptAltScreen(false))
 	}
 	return tcell.NewScreen()
+}
+
+func handleProgramPostInput(
+	policy programQuitAtEOFPolicy,
+	showLicense bool,
+	session *programSession,
+	pager *goless.Pager,
+	result programInputResult,
+	inputComplete bool,
+	following bool,
+	before goless.Position,
+	reload func() (bool, error),
+) (bool, error) {
+	if pager == nil {
+		return false, nil
+	}
+	keyResult := result.keyResult()
+	if !showLicense {
+		quit, err := handleProgramVisibleEOFAction(policy, session, func() *goless.Pager { return pager }, keyResult, inputComplete, reload)
+		if err != nil || quit {
+			return quit, err
+		}
+	}
+	return applyProgramQuitAtEOF(policy, session, keyResult, inputComplete, following, before, pager.Position(), reload)
+}
+
+func (r programInputResult) keyResult() goless.KeyResult {
+	return goless.KeyResult{
+		Handled: r.handled,
+		Quit:    r.quit,
+		Action:  r.action,
+		Context: r.context,
+	}
 }
 
 func applyProgramQuitAtEOF(

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -117,6 +117,7 @@ func run() error {
 		return err
 	}
 	defer screen.Fini()
+	screen.EnableMouse()
 
 	width, height := screen.Size()
 	if width <= 0 || height <= 0 {
@@ -262,6 +263,42 @@ func run() error {
 				return err
 			} else if quit {
 				return programExit(screen, quitAtEOFPolicy)
+			}
+			if readResult != nil {
+				quitIfOneScreenArmed = updateProgramQuitIfOneScreenArm(quitIfOneScreenArmed, pager)
+			}
+		case *tcell.EventMouse:
+			before := pager.Position()
+			beforeFollowing := pager.Following()
+			result := pager.HandleMouseResult(event)
+			if !opts.showLicense {
+				keyResult := goless.KeyResult{
+					Handled: result.Handled,
+					Action:  result.Action,
+					Context: result.Context,
+				}
+				quit, err := handleProgramVisibleEOFAction(quitAtEOFPolicy, session, func() *goless.Pager { return pager }, keyResult, readResult == nil, reloadCurrent)
+				if err != nil {
+					return err
+				}
+				pager.Draw(screen)
+				if quit {
+					return programExit(screen, quitAtEOFPolicy)
+				}
+				if quit, err := applyProgramQuitAtEOF(
+					quitAtEOFPolicy,
+					session,
+					keyResult,
+					readResult == nil,
+					beforeFollowing,
+					before,
+					pager.Position(),
+					reloadCurrent,
+				); err != nil {
+					return err
+				} else if quit {
+					return programExit(screen, quitAtEOFPolicy)
+				}
 			}
 			if readResult != nil {
 				quitIfOneScreenArmed = updateProgramQuitIfOneScreenArm(quitIfOneScreenArmed, pager)

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -473,6 +473,160 @@ func TestHandleDemoVisibleEOFActionRequiresForwardNavigation(t *testing.T) {
 	}
 }
 
+func TestHandleProgramPostInputVisibleEOFFromMouseScroll(t *testing.T) {
+	session := newProgramSession([]string{"one.txt"}, programStartup{})
+	pager := goless.New(goless.Config{TabWidth: 4, WrapMode: goless.NoWrap, ShowStatus: true})
+	pager.SetSize(20, 5)
+	if err := pager.AppendString("one\ntwo\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	quit, err := handleProgramPostInput(
+		programQuitAtEOFWhenVisible,
+		false,
+		session,
+		pager,
+		programInputResult{
+			handled: true,
+			action:  goless.KeyActionScrollDown,
+			context: goless.NormalKeyContext,
+		},
+		true,
+		false,
+		pager.Position(),
+		func() (bool, error) { return true, nil },
+	)
+	if err != nil {
+		t.Fatalf("handleProgramPostInput returned error: %v", err)
+	}
+	if !quit {
+		t.Fatal("handleProgramPostInput(...) = false, want true")
+	}
+}
+
+func TestHandleProgramPostInputQuitAtEOFUsesStationaryForwardAction(t *testing.T) {
+	session := newProgramSession([]string{"one.txt", "two.txt"}, programStartup{})
+	pager := goless.New(goless.Config{TabWidth: 4, WrapMode: goless.NoWrap, ShowStatus: true})
+	pager.SetSize(20, 5)
+	if err := pager.AppendString("one\ntwo\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	reloads := 0
+	quit, err := handleProgramPostInput(
+		programQuitAtEOFOnForwardEOF,
+		false,
+		session,
+		pager,
+		programInputResult{
+			handled: true,
+			action:  goless.KeyActionScrollDown,
+			context: goless.NormalKeyContext,
+		},
+		true,
+		false,
+		pager.Position(),
+		func() (bool, error) {
+			reloads++
+			return true, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("handleProgramPostInput returned error: %v", err)
+	}
+	if quit {
+		t.Fatal("handleProgramPostInput(...) = true, want false")
+	}
+	if got, want := reloads, 1; got != want {
+		t.Fatalf("reload count = %d, want %d", got, want)
+	}
+	if got, want := session.currentFile(), "two.txt"; got != want {
+		t.Fatalf("currentFile() = %q, want %q", got, want)
+	}
+}
+
+func TestHandleProgramPostInputIgnoresNonNormalContexts(t *testing.T) {
+	session := newProgramSession([]string{"one.txt"}, programStartup{})
+	pager := goless.New(goless.Config{TabWidth: 4, WrapMode: goless.NoWrap, ShowStatus: true})
+	pager.SetSize(20, 5)
+	if err := pager.AppendString("one\ntwo\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	for _, tt := range []struct {
+		name    string
+		context goless.KeyContext
+	}{
+		{name: "help", context: goless.HelpKeyContext},
+		{name: "prompt", context: goless.PromptKeyContext},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			quit, err := handleProgramPostInput(
+				programQuitAtEOFWhenVisible,
+				false,
+				session,
+				pager,
+				programInputResult{
+					handled: true,
+					action:  goless.KeyActionScrollDown,
+					context: tt.context,
+				},
+				true,
+				false,
+				pager.Position(),
+				func() (bool, error) {
+					t.Fatal("reload should not be called outside normal context")
+					return false, nil
+				},
+			)
+			if err != nil {
+				t.Fatalf("handleProgramPostInput returned error: %v", err)
+			}
+			if quit {
+				t.Fatal("handleProgramPostInput(...) = true, want false")
+			}
+		})
+	}
+}
+
+func TestHandleProgramPostInputSkipsEOFPoliciesForLicenseView(t *testing.T) {
+	session := newProgramSession([]string{"one.txt"}, programStartup{})
+	pager := goless.New(goless.Config{TabWidth: 4, WrapMode: goless.NoWrap, ShowStatus: true})
+	pager.SetSize(20, 5)
+	if err := pager.AppendString("one\ntwo\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	quit, err := handleProgramPostInput(
+		programQuitAtEOFWhenVisible,
+		true,
+		session,
+		pager,
+		programInputResult{
+			handled: true,
+			action:  goless.KeyActionScrollDown,
+			context: goless.NormalKeyContext,
+		},
+		true,
+		false,
+		pager.Position(),
+		func() (bool, error) {
+			t.Fatal("reload should not be called for license view")
+			return false, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("handleProgramPostInput returned error: %v", err)
+	}
+	if quit {
+		t.Fatal("handleProgramPostInput(...) = true, want false")
+	}
+}
+
 func TestParseProgramFlagsCompatibilityAliases(t *testing.T) {
 	var out bytes.Buffer
 	opts, args, err := parseProgramFlags([]string{"-F", "-S", "-N", "-s", "-x", "4", "-I", "sample.txt"}, &out)

--- a/doc.go
+++ b/doc.go
@@ -14,7 +14,8 @@
 //   - append content with Append, AppendString, or ReadFrom
 //   - size it with SetSize
 //   - render it with Draw
-//   - feed input through HandleKey, HandleKeyResult, or direct navigation/search methods
+//   - enable mouse reporting on the host tcell.Screen when wheel input is desired
+//   - feed input through HandleKey, HandleKeyResult, HandleMouse, HandleMouseResult, or direct navigation/search methods
 //   - reconfigure runtime-safe behavior with Configure and RuntimeOption values
 //   - inspect visible search state with SearchState when host chrome needs it
 //

--- a/example_test.go
+++ b/example_test.go
@@ -36,6 +36,7 @@ func ExampleNew() {
 		return
 	}
 	defer screen.Fini()
+	screen.EnableMouse()
 
 	pager.Draw(screen)
 	_ = pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, "x", tcell.ModNone))

--- a/internal/view/input.go
+++ b/internal/view/input.go
@@ -100,3 +100,10 @@ const (
 	actionCycleSearchCase
 	actionCycleSearchMode
 )
+
+// MouseResult summarizes how the viewer handled a mouse event.
+type MouseResult struct {
+	Handled bool
+	Action  KeyAction
+	Context KeyContext
+}

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -491,6 +491,11 @@ func (v *Viewer) HandleKey(ev *tcell.EventKey) bool {
 	return v.HandleKeyResult(ev).Quit
 }
 
+// HandleMouse applies a mouse event and reports whether it was handled.
+func (v *Viewer) HandleMouse(ev *tcell.EventMouse) bool {
+	return v.HandleMouseResult(ev).Handled
+}
+
 // HandleKeyResult applies a key event and reports whether it was handled and whether the viewer should exit.
 func (v *Viewer) HandleKeyResult(ev *tcell.EventKey) KeyResult {
 	if v.mode == modeHelp {
@@ -564,6 +569,32 @@ func (v *Viewer) HandleKeyResult(ev *tcell.EventKey) KeyResult {
 	}
 
 	return KeyResult{Handled: true, Action: KeyAction(a), Context: KeyContextNormal}
+}
+
+// HandleMouseResult applies a mouse event and reports whether it was handled.
+func (v *Viewer) HandleMouseResult(ev *tcell.EventMouse) MouseResult {
+	if v.mode == modeHelp {
+		return v.handleHelpMouse(ev)
+	}
+	if v.mode == modePrompt {
+		return MouseResult{Context: KeyContextPrompt}
+	}
+
+	a := wheelAction(ev.Buttons())
+	switch a {
+	case actionScrollUp:
+		v.ScrollUp(1)
+	case actionScrollDown:
+		v.ScrollDown(1)
+	case actionScrollLeft:
+		v.ScrollLeft(v.horizontalScrollStep())
+	case actionScrollRight:
+		v.ScrollRight(v.horizontalScrollStep())
+	default:
+		return MouseResult{Context: KeyContextNormal}
+	}
+
+	return MouseResult{Handled: true, Action: KeyAction(a), Context: KeyContextNormal}
 }
 
 // ToggleWrap switches between horizontal scrolling and soft wrap modes.
@@ -1924,6 +1955,21 @@ func (v *Viewer) helpPageStep() int {
 	return max(bodyHeight, 1)
 }
 
+func wheelAction(buttons tcell.ButtonMask) action {
+	switch {
+	case buttons&tcell.WheelUp != 0:
+		return actionScrollUp
+	case buttons&tcell.WheelDown != 0:
+		return actionScrollDown
+	case buttons&tcell.WheelLeft != 0:
+		return actionScrollLeft
+	case buttons&tcell.WheelRight != 0:
+		return actionScrollRight
+	default:
+		return actionNone
+	}
+}
+
 func (v *Viewer) handleHelpKey(ev *tcell.EventKey) KeyResult {
 	a := v.keys.helpAction(ev)
 	switch a {
@@ -1972,6 +2018,24 @@ func (v *Viewer) handleHelpKey(ev *tcell.EventKey) KeyResult {
 	}
 	v.clampHelpOffset()
 	return KeyResult{Handled: true, Action: KeyAction(a), Context: KeyContextHelp}
+}
+
+func (v *Viewer) handleHelpMouse(ev *tcell.EventMouse) MouseResult {
+	a := wheelAction(ev.Buttons())
+	switch a {
+	case actionScrollUp:
+		v.helpOffset--
+	case actionScrollDown:
+		v.helpOffset++
+	case actionScrollLeft:
+		v.helpColOffset -= v.horizontalScrollStep()
+	case actionScrollRight:
+		v.helpColOffset += v.horizontalScrollStep()
+	default:
+		return MouseResult{Context: KeyContextHelp}
+	}
+	v.clampHelpOffset()
+	return MouseResult{Handled: true, Action: KeyAction(a), Context: KeyContextHelp}
 }
 
 func (v *Viewer) handlePromptKey(ev *tcell.EventKey) KeyResult {

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -348,6 +348,109 @@ func TestLessKeyMapHelpRefreshAliases(t *testing.T) {
 	}
 }
 
+func TestViewerHandleMouseScrollsDocument(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("one\ntwo\nthree\nfour\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	result := v.HandleMouseResult(mouseWheel(tcell.WheelDown))
+	if !result.Handled || result.Action != KeyActionScrollDown || result.Context != KeyContextNormal {
+		t.Fatalf("HandleMouseResult(WheelDown) = %+v, want handled scroll down in normal context", result)
+	}
+	if got, want := v.Position().Row, 2; got != want {
+		t.Fatalf("Position().Row after WheelDown = %d, want %d", got, want)
+	}
+
+	result = v.HandleMouseResult(mouseWheel(tcell.WheelUp))
+	if !result.Handled || result.Action != KeyActionScrollUp || result.Context != KeyContextNormal {
+		t.Fatalf("HandleMouseResult(WheelUp) = %+v, want handled scroll up in normal context", result)
+	}
+	if got, want := v.Position().Row, 1; got != want {
+		t.Fatalf("Position().Row after WheelUp = %d, want %d", got, want)
+	}
+}
+
+func TestViewerHandleMouseScrollsHorizontally(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("abcdefghijklmnopqrstuvwxyz\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap})
+	v.SetSize(8, 2)
+
+	result := v.HandleMouseResult(mouseWheel(tcell.WheelRight))
+	if !result.Handled || result.Action != KeyActionScrollRight || result.Context != KeyContextNormal {
+		t.Fatalf("HandleMouseResult(WheelRight) = %+v, want handled scroll right in normal context", result)
+	}
+	if got, want := v.colOffset, v.horizontalScrollStep(); got != want {
+		t.Fatalf("colOffset after WheelRight = %d, want %d", got, want)
+	}
+
+	result = v.HandleMouseResult(mouseWheel(tcell.WheelLeft))
+	if !result.Handled || result.Action != KeyActionScrollLeft || result.Context != KeyContextNormal {
+		t.Fatalf("HandleMouseResult(WheelLeft) = %+v, want handled scroll left in normal context", result)
+	}
+	if got, want := v.colOffset, 0; got != want {
+		t.Fatalf("colOffset after WheelLeft = %d, want %d", got, want)
+	}
+}
+
+func TestViewerHandleMouseScrollsHelpOverlay(t *testing.T) {
+	doc := model.NewDocument(4)
+	v := New(doc, Config{
+		TabWidth: 4,
+		WrapMode: layout.NoWrap,
+		Text: Text{
+			HelpBody: "0123456789abcdef\none\ntwo\nthree\nfour\n",
+		},
+	})
+	v.SetSize(8, 3)
+	v.mode = modeHelp
+
+	result := v.HandleMouseResult(mouseWheel(tcell.WheelDown))
+	if !result.Handled || result.Action != KeyActionScrollDown || result.Context != KeyContextHelp {
+		t.Fatalf("HandleMouseResult(WheelDown) = %+v, want handled scroll down in help context", result)
+	}
+	if got, want := v.helpOffset, 1; got != want {
+		t.Fatalf("helpOffset after WheelDown = %d, want %d", got, want)
+	}
+
+	result = v.HandleMouseResult(mouseWheel(tcell.WheelRight))
+	if !result.Handled || result.Action != KeyActionScrollRight || result.Context != KeyContextHelp {
+		t.Fatalf("HandleMouseResult(WheelRight) = %+v, want handled scroll right in help context", result)
+	}
+	if got, want := v.helpColOffset, v.horizontalScrollStep(); got != want {
+		t.Fatalf("helpColOffset after WheelRight = %d, want %d", got, want)
+	}
+}
+
+func TestViewerHandleMousePromptContextIsUnhandled(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("one\ntwo\nthree\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+	v.HandleKey(keyRune("/"))
+
+	result := v.HandleMouseResult(mouseWheel(tcell.WheelDown))
+	if result.Handled {
+		t.Fatalf("HandleMouseResult(WheelDown).Handled = true, want false in prompt")
+	}
+	if got, want := result.Context, KeyContextPrompt; got != want {
+		t.Fatalf("HandleMouseResult(WheelDown).Context = %v, want %v", got, want)
+	}
+	if got, want := v.Position().Row, 1; got != want {
+		t.Fatalf("Position().Row after WheelDown in prompt = %d, want %d", got, want)
+	}
+}
+
 func TestViewerRuntimeSettersUpdateConfigAndState(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("a\tb\n")); err != nil {
@@ -3867,6 +3970,10 @@ func keyKey(k tcell.Key) *tcell.EventKey {
 
 func keyKeyMod(k tcell.Key, mod tcell.ModMask) *tcell.EventKey {
 	return tcell.NewEventKey(k, "", mod)
+}
+
+func mouseWheel(button tcell.ButtonMask) *tcell.EventMouse {
+	return tcell.NewEventMouse(0, 0, button, tcell.ModNone)
 }
 
 func cellRune(screen tcell.Screen, x, y int) rune {

--- a/pager.go
+++ b/pager.go
@@ -64,6 +64,13 @@ type KeyResult struct {
 	Context KeyContext
 }
 
+// MouseResult summarizes how the pager handled a mouse event.
+type MouseResult struct {
+	Handled bool
+	Action  KeyAction
+	Context KeyContext
+}
+
 // Command describes a ':' command entered through the built-in prompt.
 type Command struct {
 	Raw  string
@@ -299,6 +306,12 @@ func (p *Pager) HandleKey(ev *tcell.EventKey) bool {
 	return p.HandleKeyResult(ev).Quit
 }
 
+// HandleMouse applies a mouse event and reports whether it was handled.
+// Callers must enable mouse reporting on their tcell screen to receive wheel events.
+func (p *Pager) HandleMouse(ev *tcell.EventMouse) bool {
+	return p.HandleMouseResult(ev).Handled
+}
+
 // HandleKeyResult applies a key event and reports whether it was handled and whether the caller should exit.
 func (p *Pager) HandleKeyResult(ev *tcell.EventKey) KeyResult {
 	if p.captureKey != nil && p.captureKey(ev) {
@@ -308,6 +321,17 @@ func (p *Pager) HandleKeyResult(ev *tcell.EventKey) KeyResult {
 	return KeyResult{
 		Handled: result.Handled,
 		Quit:    result.Quit,
+		Action:  KeyAction(result.Action),
+		Context: KeyContext(result.Context),
+	}
+}
+
+// HandleMouseResult applies a mouse event and reports whether it was handled.
+// Callers must enable mouse reporting on their tcell screen to receive wheel events.
+func (p *Pager) HandleMouseResult(ev *tcell.EventMouse) MouseResult {
+	result := p.viewer.HandleMouseResult(ev)
+	return MouseResult{
+		Handled: result.Handled,
 		Action:  KeyAction(result.Action),
 		Context: KeyContext(result.Context),
 	}

--- a/pager_test.go
+++ b/pager_test.go
@@ -118,6 +118,62 @@ func TestPagerHandleKeyResultPromptContext(t *testing.T) {
 	}
 }
 
+func TestPagerHandleMouse(t *testing.T) {
+	pager := New(Config{TabWidth: 4, WrapMode: NoWrap, ShowStatus: true})
+	pager.SetSize(20, 2)
+	if err := pager.AppendString("one\ntwo\nthree\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	if !pager.HandleMouse(tcell.NewEventMouse(0, 0, tcell.WheelDown, tcell.ModNone)) {
+		t.Fatal("HandleMouse(WheelDown) = false, want true")
+	}
+	if got, want := pager.Position().Row, 2; got != want {
+		t.Fatalf("Position().Row after WheelDown = %d, want %d", got, want)
+	}
+}
+
+func TestPagerHandleMouseResult(t *testing.T) {
+	pager := New(Config{TabWidth: 4, WrapMode: NoWrap, ShowStatus: true})
+	pager.SetSize(8, 2)
+	if err := pager.AppendString("abcdefghijklmnopqrstuvwxyz\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	result := pager.HandleMouseResult(tcell.NewEventMouse(0, 0, tcell.WheelRight, tcell.ModNone))
+	if !result.Handled {
+		t.Fatal("HandleMouseResult(WheelRight).Handled = false, want true")
+	}
+	if got, want := result.Action, KeyActionScrollRight; got != want {
+		t.Fatalf("HandleMouseResult(WheelRight).Action = %v, want %v", got, want)
+	}
+	if got, want := result.Context, NormalKeyContext; got != want {
+		t.Fatalf("HandleMouseResult(WheelRight).Context = %v, want %v", got, want)
+	}
+	if got := pager.Position().Column; got <= 1 {
+		t.Fatalf("Position().Column after WheelRight = %d, want > 1", got)
+	}
+}
+
+func TestPagerHandleMouseResultHelpContext(t *testing.T) {
+	pager := New(Config{TabWidth: 4, WrapMode: NoWrap, ShowStatus: true})
+	pager.SetSize(20, 4)
+	pager.ShowInformation("Help", "one\ntwo\nthree\nfour\nfive\n")
+
+	result := pager.HandleMouseResult(tcell.NewEventMouse(0, 0, tcell.WheelDown, tcell.ModNone))
+	if !result.Handled {
+		t.Fatal("HandleMouseResult(WheelDown).Handled = false, want true")
+	}
+	if got, want := result.Action, KeyActionScrollDown; got != want {
+		t.Fatalf("HandleMouseResult(WheelDown).Action = %v, want %v", got, want)
+	}
+	if got, want := result.Context, HelpKeyContext; got != want {
+		t.Fatalf("HandleMouseResult(WheelDown).Context = %v, want %v", got, want)
+	}
+}
+
 func TestPagerShowInformation(t *testing.T) {
 	pager := New(Config{TabWidth: 4, WrapMode: NoWrap, ShowStatus: true})
 	pager.SetSize(24, 6)


### PR DESCRIPTION
fixes #89

This provides mouse wheel support for scrolling, in both axes. Tested in Ghostty, iTerm, macOS Terminal.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mouse-wheel support for vertical and horizontal scrolling across viewing modes and controls
  * Mouse input is now handled alongside keyboard input for unified interaction

* **Documentation**
  * Updated docs and examples to explain enabling mouse support and how to drive interaction with key+mouse

* **Tests**
  * Added tests covering mouse-wheel behavior in normal, help, and prompt contexts
<!-- end of auto-generated comment: release notes by coderabbit.ai -->