### PR TITLE
Add support for "v" to spawn an EDITOR ('vi' by default)

### DIFF
--- a/LESS_COMPATIBILITY.md
+++ b/LESS_COMPATIBILITY.md
@@ -141,6 +141,7 @@ Implemented:
 - `=`
 - `Ctrl-G`
 - `:reload`
+- `v` to launch `$EDITOR` for the current file, unless `-secure` is set
 
 `=` and `Ctrl-G` report the same current-file/session status already available
 through `:file`.
@@ -190,7 +191,6 @@ These should remain intentionally unsupported unless the project direction
 changes:
 
 - shell escape commands such as `!`, `#`, and `|`
-- editor launch via `v`
 - save-to-file commands
 - `LESSOPEN`, lesskey, and other external-process integration points
 - raw control-character passthrough mode `-r`

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ similar to `less`.
 
 It is designed both for applications that need to display untrusted text safely
 inside their own terminal UI and for the emerging standalone `goless` program,
-without shell escapes, subprocess hooks, or raw terminal control passthrough.
+without shell escapes or raw terminal control passthrough in the pager core.
 It is implemented in pure Go, targets [`tcell`](https://github.com/gdamore/tcell),
 and does not rely on cgo.
 
@@ -68,8 +68,10 @@ hugo server --source site
   the host terminal
 - Parsed OSC 8 hyperlinks are inert by default. An embedder must opt in with
   `HyperlinkHandler` before content becomes a live link.
-- There is no shell escape support, editor launch support, or subprocess
-  execution support
+- The pager core does not expose shell escape support or arbitrary subprocess
+  execution
+- The standalone `goless` program can launch `$EDITOR` for the current file
+  with `v`; `-secure` disables that command
 
 That is the core contract of the package: applications can display hostile or
 arbitrary text without handing terminal control to the input stream.
@@ -334,6 +336,7 @@ Program flags:
 - `-N` to enable line numbers
 - `-R` accepted as a less-compatibility no-op
 - `-S` accepted as a less-compatibility no-op because no-wrap is already the default
+- `-secure` to disable standalone commands that launch external programs
 - `-i` for smart-case search behavior
 - `-I` for case-insensitive search behavior
 - `--license` to open the bundled Apache license, or print it when stdout is not a terminal
@@ -357,6 +360,7 @@ The default key group is intentionally less-like. Common bindings include:
 - `g`/`G` for top/bottom
 - `W` to toggle wrap
 - `r` or `Ctrl-L` to repaint the screen
+- `v` to open the current file in `$EDITOR` at the current line unless `-secure` is set
 - `/` and `?` to search forward/backward
 - `n` and `N` to repeat search
 - `F2` to cycle search case mode in the bundled key group

--- a/cmd/goless/help.txt
+++ b/cmd/goless/help.txt
@@ -3,6 +3,7 @@
  q Q Esc             quit
   r ^L                repaint
   R                   reload current file/input
+  v                   edit current file using $EDITOR
   F4                  cycle themes
 
 [1;4mNavigation[0m

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"runtime/debug"
 	"slices"
 	"strconv"
@@ -46,6 +47,7 @@ type programOptions struct {
 	quitIfOneScreen   bool
 	renderName        string
 	searchCaseMode    goless.SearchCaseMode
+	secure            bool
 	showHelp          bool
 	showLicense       bool
 	squeeze           bool
@@ -65,7 +67,6 @@ type programInputResult struct {
 	action  goless.KeyAction
 	context goless.KeyContext
 }
-
 type programFileFollower struct {
 	path  string
 	pager *goless.Pager
@@ -80,6 +81,7 @@ var (
 	programStdoutIsTerminalFunc     = stdoutIsTerminal
 	programDefaultScreenFactory     = tcell.NewScreen
 	programTerminfoScreenFactory    = tcell.NewTerminfoScreen
+	programEditorLauncher           = launchProgramEditor
 )
 
 func main() {
@@ -208,6 +210,9 @@ func run() error {
 						pager.ShowInformation(title, body)
 					}
 				},
+				func() error {
+					return editProgramCurrentFile(screen, pager, session, opts.secure, reloadDisplayed)
+				},
 			),
 		)
 	}
@@ -306,6 +311,10 @@ func run() error {
 				break
 			}
 			if shouldHandleProgramStatusKey(keyResult) && handleProgramStatusKey(pager, event) {
+				pager.Draw(screen)
+				break
+			}
+			if shouldHandleProgramEditKey(keyResult) && handleProgramEditKey(pager, event) {
 				pager.Draw(screen)
 				break
 			}
@@ -415,7 +424,7 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 	fs := flag.NewFlagSet("goless", flag.ContinueOnError)
 	fs.SetOutput(output)
 	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "usage: goless [-?|-e|-E|-F|-N|-R|-S|-i|-I|-s] [-x n] [-preset dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [-license] [+line|+/pattern] [-version] [path ...]\n")
+		fmt.Fprintf(fs.Output(), "usage: goless [-?|-e|-E|-F|-N|-R|-S|-i|-I|-s|-secure] [-x n] [-preset dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [-license] [+line|+/pattern] [-version] [path ...]\n")
 	}
 
 	fs.BoolVar(&opts.showHelp, "?", false, "show help")
@@ -432,6 +441,7 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 	fs.BoolVar(&opts.liveLinks, "live-links", false, "enable live OSC 8 hyperlinks in the program")
 	fs.BoolVar(&opts.quitAtEOF, "quit-at-eof", false, "long form of -e")
 	fs.BoolVar(&opts.quitAtEOFFirst, "QUIT-AT-EOF", false, "long form of -E")
+	fs.BoolVar(&opts.secure, "secure", false, "disable standalone commands that launch external programs")
 	fs.BoolVar(&opts.squeeze, "s", false, "collapse repeated blank lines in the current view")
 	fs.BoolVar(&opts.squeeze, "squeeze", false, "collapse repeated blank lines in the current view")
 	fs.StringVar(&opts.presetName, "preset", "pretty", "visual preset: none, dark, light, plain, pretty")
@@ -1065,11 +1075,19 @@ func (s *programSession) last() bool {
 	return true
 }
 
-func (s *programSession) commandHandler(load func() error, reload func() error, showInformation func(title, body string)) func(goless.Command) goless.CommandResult {
+func (s *programSession) commandHandler(load func() error, reload func() error, showInformation func(title, body string), edit func() error) func(goless.Command) goless.CommandResult {
 	return func(cmd goless.Command) goless.CommandResult {
 		switch cmd.Name {
 		case "q", "Q", "quit":
 			return goless.CommandResult{Handled: true, Quit: true}
+		case "v", "edit":
+			if edit == nil {
+				return goless.CommandResult{Handled: true, Message: "editor unavailable for current input"}
+			}
+			if err := edit(); err != nil {
+				return goless.CommandResult{Handled: true, Message: err.Error()}
+			}
+			return goless.CommandResult{Handled: true}
 		case "file", "f":
 			return goless.CommandResult{Handled: true, Message: s.currentFileLabel()}
 		case "license":
@@ -1178,6 +1196,20 @@ func shouldHandleProgramReloadKey(result goless.KeyResult) bool {
 	return !result.Handled && result.Context == goless.NormalKeyContext
 }
 
+func handleProgramEditKey(pager *goless.Pager, ev *tcell.EventKey) bool {
+	if pager == nil || ev == nil {
+		return false
+	}
+	if ev.Key() != tcell.KeyRune || ev.Str() != "v" || ev.Modifiers() != tcell.ModNone {
+		return false
+	}
+	return runProgramCommand(pager, "v")
+}
+
+func shouldHandleProgramEditKey(result goless.KeyResult) bool {
+	return !result.Handled && result.Context == goless.NormalKeyContext
+}
+
 func runProgramCommand(pager *goless.Pager, command string) bool {
 	if pager == nil || command == "" {
 		return false
@@ -1188,6 +1220,136 @@ func runProgramCommand(pager *goless.Pager, command string) bool {
 	}
 	pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyEnter, "", tcell.ModNone))
 	return true
+}
+
+func editProgramCurrentFile(screen tcell.Screen, pager *goless.Pager, session *programSession, secure bool, reload func() error) error {
+	if secure {
+		return fmt.Errorf("editor disabled in secure mode")
+	}
+	if session == nil {
+		return fmt.Errorf("editor unavailable for current input")
+	}
+	path := session.currentFile()
+	if path == "" || isProgramStdinInput(path) {
+		return fmt.Errorf("editor unavailable for current input")
+	}
+	line := 1
+	if pager != nil {
+		if row := pager.Position().Row; row > 0 {
+			line = row
+		}
+	}
+	if err := suspendProgramScreen(screen, pager, func() error {
+		return programEditorLauncher(line, path)
+	}); err != nil {
+		return err
+	}
+	if reload != nil {
+		return reload()
+	}
+	return nil
+}
+
+func suspendProgramScreen(screen tcell.Screen, pager *goless.Pager, action func() error) error {
+	if action == nil {
+		return nil
+	}
+	if screen == nil {
+		return action()
+	}
+	screen.Fini()
+	actionErr := action()
+	initErr := screen.Init()
+	if initErr == nil {
+		screen.EnableMouse()
+		if pager != nil {
+			width, height := screen.Size()
+			pager.SetSize(width, height)
+		}
+		screen.Sync()
+	}
+	if actionErr != nil {
+		if initErr != nil {
+			return fmt.Errorf("%v; screen restore failed: %w", actionErr, initErr)
+		}
+		return actionErr
+	}
+	return initErr
+}
+
+func launchProgramEditor(line int, path string) error {
+	editor := os.Getenv("EDITOR")
+	if strings.TrimSpace(editor) == "" {
+		return fmt.Errorf("EDITOR is not set")
+	}
+	args, err := splitProgramEditor(editor)
+	if err != nil {
+		return fmt.Errorf("invalid EDITOR: %w", err)
+	}
+	args = append(args, fmt.Sprintf("+%d", line), path)
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+func splitProgramEditor(spec string) ([]string, error) {
+	var (
+		args        []string
+		current     strings.Builder
+		quote       rune
+		escaped     bool
+		tokenActive bool
+	)
+	flush := func() {
+		if !tokenActive {
+			return
+		}
+		args = append(args, current.String())
+		current.Reset()
+		tokenActive = false
+	}
+	for _, r := range spec {
+		switch {
+		case escaped:
+			current.WriteRune(r)
+			tokenActive = true
+			escaped = false
+		case quote != 0:
+			switch {
+			case r == quote:
+				quote = 0
+			case quote == '"' && r == '\\':
+				escaped = true
+			default:
+				current.WriteRune(r)
+				tokenActive = true
+			}
+		case r == '\\':
+			escaped = true
+			tokenActive = true
+		case r == '\'' || r == '"':
+			quote = r
+			tokenActive = true
+		case r == ' ' || r == '\t' || r == '\n' || r == '\r':
+			flush()
+		default:
+			current.WriteRune(r)
+			tokenActive = true
+		}
+	}
+	if escaped {
+		return nil, fmt.Errorf("trailing escape")
+	}
+	if quote != 0 {
+		return nil, fmt.Errorf("unterminated quote")
+	}
+	flush()
+	if len(args) == 0 {
+		return nil, fmt.Errorf("empty command")
+	}
+	return args, nil
 }
 
 func snapshotProgramPager(pager *goless.Pager) programViewportSnapshot {

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -1278,9 +1278,9 @@ func suspendProgramScreen(screen tcell.Screen, pager *goless.Pager, action func(
 }
 
 func launchProgramEditor(line int, path string) error {
-	editor := os.Getenv("EDITOR")
-	if strings.TrimSpace(editor) == "" {
-		return fmt.Errorf("EDITOR is not set")
+	editor := strings.TrimSpace(os.Getenv("EDITOR"))
+	if editor == "" {
+		editor = "vi"
 	}
 	args, err := splitProgramEditor(editor)
 	if err != nil {
@@ -1299,7 +1299,6 @@ func splitProgramEditor(spec string) ([]string, error) {
 		args        []string
 		current     strings.Builder
 		quote       rune
-		escaped     bool
 		tokenActive bool
 	)
 	flush := func() {
@@ -1310,25 +1309,33 @@ func splitProgramEditor(spec string) ([]string, error) {
 		current.Reset()
 		tokenActive = false
 	}
-	for _, r := range spec {
+	runes := []rune(spec)
+	for i := 0; i < len(runes); i++ {
+		r := runes[i]
 		switch {
-		case escaped:
+		case quote == '\'':
+			if r == '\'' {
+				quote = 0
+				continue
+			}
 			current.WriteRune(r)
 			tokenActive = true
-			escaped = false
-		case quote != 0:
+		case quote == '"':
 			switch {
 			case r == quote:
 				quote = 0
-			case quote == '"' && r == '\\':
-				escaped = true
+			case r == '\\':
+				if i+1 < len(runes) && (runes[i+1] == '"' || runes[i+1] == '\\') {
+					i++
+					current.WriteRune(runes[i])
+				} else {
+					current.WriteRune(r)
+				}
+				tokenActive = true
 			default:
 				current.WriteRune(r)
 				tokenActive = true
 			}
-		case r == '\\':
-			escaped = true
-			tokenActive = true
 		case r == '\'' || r == '"':
 			quote = r
 			tokenActive = true
@@ -1338,9 +1345,6 @@ func splitProgramEditor(spec string) ([]string, error) {
 			current.WriteRune(r)
 			tokenActive = true
 		}
-	}
-	if escaped {
-		return nil, fmt.Errorf("trailing escape")
 	}
 	if quote != 0 {
 		return nil, fmt.Errorf("unterminated quote")

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -861,6 +861,23 @@ func TestParseProgramFlagsCompatibilityAliases(t *testing.T) {
 	}
 }
 
+func TestParseProgramFlagsSecure(t *testing.T) {
+	var out bytes.Buffer
+	opts, args, err := parseProgramFlags([]string{"-secure", "sample.txt"}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(-secure) failed: %v", err)
+	}
+	if !opts.secure {
+		t.Fatal("parseProgramFlags(-secure) did not enable secure mode")
+	}
+	if got, want := len(args), 1; got != want {
+		t.Fatalf("len(args) = %d, want %d", got, want)
+	}
+	if got, want := args[0], "sample.txt"; got != want {
+		t.Fatalf("args[0] = %q, want %q", got, want)
+	}
+}
+
 func TestParseProgramFlagsRejectsConflictingSearchCaseFlags(t *testing.T) {
 	var out bytes.Buffer
 
@@ -1250,7 +1267,7 @@ func TestDemoSessionCommandHandler(t *testing.T) {
 	}, func() error {
 		reloads++
 		return nil
-	}, nil)
+	}, nil, nil)
 
 	if result := handler(goless.Command{Name: "quit"}); !result.Handled || !result.Quit {
 		t.Fatalf("quit command result = %+v, want handled quit", result)
@@ -1323,7 +1340,7 @@ func TestDemoSessionAdditionalCommands(t *testing.T) {
 		return nil
 	}, func() error {
 		return nil
-	}, nil)
+	}, nil, nil)
 
 	result := handler(goless.Command{Name: "file"})
 	if !result.Handled || result.Quit {
@@ -1390,7 +1407,7 @@ func TestDemoSessionLicenseCommandShowsBundledLicense(t *testing.T) {
 	}, func(gotTitle, gotBody string) {
 		title = gotTitle
 		body = gotBody
-	})
+	}, nil)
 
 	result := handler(goless.Command{Name: "license"})
 	if !result.Handled || result.Quit {
@@ -1407,6 +1424,41 @@ func TestDemoSessionLicenseCommandShowsBundledLicense(t *testing.T) {
 	}
 	if !strings.Contains(body, "Version 2.0, January 2004") {
 		t.Fatalf("license body missing version heading: %q", body)
+	}
+}
+
+func TestDemoSessionEditCommand(t *testing.T) {
+	session := newProgramSession([]string{"one.txt"}, programStartup{})
+	edits := 0
+	handler := session.commandHandler(nil, nil, nil, func() error {
+		edits++
+		return nil
+	})
+
+	result := handler(goless.Command{Name: "v"})
+	if !result.Handled || result.Quit {
+		t.Fatalf("edit command result = %+v, want handled non-quit", result)
+	}
+	if got, want := result.Message, ""; got != want {
+		t.Fatalf("edit command message = %q, want empty", got)
+	}
+	if got, want := edits, 1; got != want {
+		t.Fatalf("edit count = %d, want %d", got, want)
+	}
+}
+
+func TestDemoSessionEditCommandReturnsError(t *testing.T) {
+	session := newProgramSession([]string{"one.txt"}, programStartup{})
+	handler := session.commandHandler(nil, nil, nil, func() error {
+		return fmt.Errorf("EDITOR is not set")
+	})
+
+	result := handler(goless.Command{Name: "edit"})
+	if !result.Handled || result.Quit {
+		t.Fatalf("edit error result = %+v, want handled non-quit", result)
+	}
+	if got, want := result.Message, "EDITOR is not set"; got != want {
+		t.Fatalf("edit error message = %q, want %q", got, want)
 	}
 }
 
@@ -1496,6 +1548,40 @@ func TestHandleProgramReloadKey(t *testing.T) {
 	}
 }
 
+func TestHandleProgramEditKey(t *testing.T) {
+	var seen []string
+	pager := goless.New(goless.Config{
+		TabWidth:   4,
+		WrapMode:   goless.NoWrap,
+		ShowStatus: true,
+		CommandHandler: func(cmd goless.Command) goless.CommandResult {
+			seen = append(seen, cmd.Name)
+			if cmd.Name == "v" {
+				return goless.CommandResult{Handled: true}
+			}
+			return goless.CommandResult{}
+		},
+	})
+	pager.SetSize(20, 2)
+	if err := pager.AppendString("one\ntwo\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+
+	if !handleProgramEditKey(pager, tcell.NewEventKey(tcell.KeyRune, "v", tcell.ModNone)) {
+		t.Fatal("handleProgramEditKey(v) = false, want true")
+	}
+	if got, want := len(seen), 1; got != want {
+		t.Fatalf("command count after v = %d, want %d", got, want)
+	}
+	if got, want := seen[0], "v"; got != want {
+		t.Fatalf("command after v = %q, want %q", got, want)
+	}
+	if handleProgramEditKey(pager, tcell.NewEventKey(tcell.KeyRune, "v", tcell.ModAlt)) {
+		t.Fatal("handleProgramEditKey(Alt-v) = true, want false")
+	}
+}
+
 func TestShouldHandleProgramReloadKey(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -1512,6 +1598,27 @@ func TestShouldHandleProgramReloadKey(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := shouldHandleProgramReloadKey(tt.result); got != tt.want {
 				t.Fatalf("shouldHandleProgramReloadKey(%+v) = %v, want %v", tt.result, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestShouldHandleProgramEditKey(t *testing.T) {
+	tests := []struct {
+		name   string
+		result goless.KeyResult
+		want   bool
+	}{
+		{name: "normal-unhandled", result: goless.KeyResult{}, want: true},
+		{name: "normal-handled", result: goless.KeyResult{Handled: true, Context: goless.NormalKeyContext}, want: false},
+		{name: "prompt-unhandled", result: goless.KeyResult{Context: goless.PromptKeyContext}, want: false},
+		{name: "help-unhandled", result: goless.KeyResult{Context: goless.HelpKeyContext}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldHandleProgramEditKey(tt.result); got != tt.want {
+				t.Fatalf("shouldHandleProgramEditKey(%+v) = %v, want %v", tt.result, got, tt.want)
 			}
 		})
 	}
@@ -1568,7 +1675,7 @@ func TestDemoSessionLabelsExplicitStdin(t *testing.T) {
 		return nil
 	}, func() error {
 		return nil
-	}, nil)
+	}, nil, nil)
 
 	result := handler(goless.Command{Name: "next"})
 	if !result.Handled || result.Quit {
@@ -1596,7 +1703,7 @@ func TestDemoSessionCommandHandlerBlocksNavigationWhileStdinReading(t *testing.T
 		return fmt.Errorf("stdin still reading")
 	}, func() error {
 		return fmt.Errorf("stdin still reading")
-	}, nil)
+	}, nil, nil)
 
 	result := handler(goless.Command{Name: "next"})
 	if !result.Handled || result.Quit {
@@ -1616,7 +1723,7 @@ func TestDemoSessionCommandHandlerReloadFailureRestoresIndex(t *testing.T) {
 		return fmt.Errorf("reload failed")
 	}, func() error {
 		return fmt.Errorf("reload failed")
-	}, nil)
+	}, nil, nil)
 
 	result := handler(goless.Command{Name: "next"})
 	if !result.Handled || result.Quit {
@@ -1636,7 +1743,7 @@ func TestDemoSessionCommandHandlerReloadFailureRestoresIndexForLast(t *testing.T
 		return fmt.Errorf("reload failed")
 	}, func() error {
 		return fmt.Errorf("reload failed")
-	}, nil)
+	}, nil, nil)
 
 	result := handler(goless.Command{Name: "last"})
 	if !result.Handled || result.Quit {
@@ -1660,7 +1767,7 @@ func TestDemoSessionCommandHandlerReloadUsesReloadHook(t *testing.T) {
 	}, func() error {
 		reloads++
 		return nil
-	}, nil)
+	}, nil, nil)
 
 	result := handler(goless.Command{Name: "reload"})
 	if !result.Handled || result.Quit {
@@ -1685,7 +1792,7 @@ func TestDemoSessionCommandHandlerReloadUnavailable(t *testing.T) {
 	handler := session.commandHandler(func() error {
 		t.Fatal("load should not be called when reload is unavailable")
 		return nil
-	}, nil, nil)
+	}, nil, nil, nil)
 
 	result := handler(goless.Command{Name: "reload"})
 	if !result.Handled || result.Quit {
@@ -1701,7 +1808,7 @@ func TestDemoSessionCommandHandlerNextUnavailable(t *testing.T) {
 	handler := session.commandHandler(nil, func() error {
 		t.Fatal("reload should not be called when load is unavailable")
 		return nil
-	}, nil)
+	}, nil, nil)
 
 	result := handler(goless.Command{Name: "next"})
 	if !result.Handled || result.Quit {
@@ -1753,7 +1860,7 @@ func TestDemoSessionCommandHandlerNavigationUnavailable(t *testing.T) {
 			handler := session.commandHandler(nil, func() error {
 				t.Fatal("reload should not be called when load is unavailable")
 				return nil
-			}, nil)
+			}, nil, nil)
 
 			result := handler(goless.Command{Name: tt.command})
 			if !result.Handled || result.Quit {
@@ -1776,7 +1883,7 @@ func TestDemoSessionCommandHandlerReloadFailureReturnsMessage(t *testing.T) {
 		return nil
 	}, func() error {
 		return fmt.Errorf("reload failed")
-	}, nil)
+	}, nil, nil)
 
 	result := handler(goless.Command{Name: "reload"})
 	if !result.Handled || result.Quit {
@@ -1890,6 +1997,152 @@ func TestApplyStartupCommand(t *testing.T) {
 	}
 	if got, want := pager.Position().Row, 2; got != want {
 		t.Fatalf("Position().Row after startup search = %d, want %d", got, want)
+	}
+}
+
+func TestEditProgramCurrentFileUsesCurrentLineAndReloads(t *testing.T) {
+	previous := programEditorLauncher
+	t.Cleanup(func() {
+		programEditorLauncher = previous
+	})
+
+	var (
+		gotLine int
+		gotPath string
+	)
+	programEditorLauncher = func(line int, path string) error {
+		gotLine = line
+		gotPath = path
+		return nil
+	}
+
+	term := vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 24})
+	screen, err := tcell.NewTerminfoScreenFromTty(term)
+	if err != nil {
+		t.Fatalf("NewTerminfoScreenFromTty failed: %v", err)
+	}
+	if err := screen.Init(); err != nil {
+		t.Fatalf("screen.Init failed: %v", err)
+	}
+	defer screen.Fini()
+
+	pager := goless.New(goless.Config{TabWidth: 4, WrapMode: goless.NoWrap, ShowStatus: true})
+	pager.SetSize(20, 3)
+	if err := pager.AppendString("one\ntwo\nthree\nfour\n"); err != nil {
+		t.Fatalf("AppendString failed: %v", err)
+	}
+	pager.Flush()
+	pager.JumpToLine(3)
+
+	path := filepath.Join(t.TempDir(), "sample.txt")
+	session := newProgramSession([]string{path}, programStartup{})
+	reloads := 0
+	if err := editProgramCurrentFile(screen, pager, session, false, func() error {
+		reloads++
+		return nil
+	}); err != nil {
+		t.Fatalf("editProgramCurrentFile(...) failed: %v", err)
+	}
+	if got, want := gotLine, 3; got != want {
+		t.Fatalf("editor line = %d, want %d", got, want)
+	}
+	if got, want := gotPath, path; got != want {
+		t.Fatalf("editor path = %q, want %q", got, want)
+	}
+	if got, want := reloads, 1; got != want {
+		t.Fatalf("reload count = %d, want %d", got, want)
+	}
+}
+
+func TestEditProgramCurrentFileSecureMode(t *testing.T) {
+	session := newProgramSession([]string{"sample.txt"}, programStartup{})
+	err := editProgramCurrentFile(nil, nil, session, true, nil)
+	if err == nil {
+		t.Fatal("editProgramCurrentFile(..., secure=true, ...) = nil error, want error")
+	}
+	if got, want := err.Error(), "editor disabled in secure mode"; got != want {
+		t.Fatalf("secure mode error = %q, want %q", got, want)
+	}
+}
+
+func TestEditProgramCurrentFileRejectsCurrentInputWithoutFile(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		session *programSession
+	}{
+		{name: "nil session"},
+		{name: "stdin session", session: newProgramSession([]string{"-"}, programStartup{})},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			err := editProgramCurrentFile(nil, nil, tt.session, false, nil)
+			if err == nil {
+				t.Fatal("editProgramCurrentFile(...) = nil error, want error")
+			}
+			if got, want := err.Error(), "editor unavailable for current input"; got != want {
+				t.Fatalf("error = %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestSplitProgramEditor(t *testing.T) {
+	tests := []struct {
+		name    string
+		spec    string
+		want    []string
+		wantErr bool
+	}{
+		{name: "simple", spec: "vim", want: []string{"vim"}},
+		{name: "with args", spec: "vim -u NONE", want: []string{"vim", "-u", "NONE"}},
+		{name: "quoted path", spec: "\"/Applications/Vim MacVim.app/Contents/bin/mvim\" -f", want: []string{"/Applications/Vim MacVim.app/Contents/bin/mvim", "-f"}},
+		{name: "single quotes", spec: "'/opt/editor bin/vim' -u NONE", want: []string{"/opt/editor bin/vim", "-u", "NONE"}},
+		{name: "unterminated quote", spec: "\"vim", wantErr: true},
+		{name: "trailing escape", spec: "vim\\", wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := splitProgramEditor(tt.spec)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("splitProgramEditor(...) = nil error, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("splitProgramEditor(...) failed: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(args) = %d, want %d", len(got), len(tt.want))
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("args[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLaunchProgramEditorRequiresEditor(t *testing.T) {
+	previous := os.Getenv("EDITOR")
+	if err := os.Unsetenv("EDITOR"); err != nil {
+		t.Fatalf("Unsetenv(EDITOR) failed: %v", err)
+	}
+	t.Cleanup(func() {
+		if previous == "" {
+			_ = os.Unsetenv("EDITOR")
+			return
+		}
+		_ = os.Setenv("EDITOR", previous)
+	})
+
+	err := launchProgramEditor(3, "sample.txt")
+	if err == nil {
+		t.Fatal("launchProgramEditor(...) = nil error, want error")
+	}
+	if got, want := err.Error(), "EDITOR is not set"; got != want {
+		t.Fatalf("launchProgramEditor error = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -2095,9 +2095,10 @@ func TestSplitProgramEditor(t *testing.T) {
 		{name: "simple", spec: "vim", want: []string{"vim"}},
 		{name: "with args", spec: "vim -u NONE", want: []string{"vim", "-u", "NONE"}},
 		{name: "quoted path", spec: "\"/Applications/Vim MacVim.app/Contents/bin/mvim\" -f", want: []string{"/Applications/Vim MacVim.app/Contents/bin/mvim", "-f"}},
+		{name: "quoted windows path", spec: "\"C:\\Program Files\\Vim\\vim.exe\" -f", want: []string{"C:\\Program Files\\Vim\\vim.exe", "-f"}},
 		{name: "single quotes", spec: "'/opt/editor bin/vim' -u NONE", want: []string{"/opt/editor bin/vim", "-u", "NONE"}},
 		{name: "unterminated quote", spec: "\"vim", wantErr: true},
-		{name: "trailing escape", spec: "vim\\", wantErr: true},
+		{name: "literal trailing backslash", spec: "vim\\", want: []string{"vim\\"}},
 	}
 
 	for _, tt := range tests {
@@ -2124,25 +2125,40 @@ func TestSplitProgramEditor(t *testing.T) {
 	}
 }
 
-func TestLaunchProgramEditorRequiresEditor(t *testing.T) {
+func TestLaunchProgramEditorDefaultsToVi(t *testing.T) {
+	dir := t.TempDir()
+	argsFile := filepath.Join(dir, "vi.args")
+	script := filepath.Join(dir, "vi")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+argsFile+"\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(vi) failed: %v", err)
+	}
+
 	previous := os.Getenv("EDITOR")
 	if err := os.Unsetenv("EDITOR"); err != nil {
 		t.Fatalf("Unsetenv(EDITOR) failed: %v", err)
 	}
+	previousPath := os.Getenv("PATH")
+	if err := os.Setenv("PATH", dir+string(os.PathListSeparator)+previousPath); err != nil {
+		t.Fatalf("Setenv(PATH) failed: %v", err)
+	}
 	t.Cleanup(func() {
 		if previous == "" {
 			_ = os.Unsetenv("EDITOR")
-			return
+		} else {
+			_ = os.Setenv("EDITOR", previous)
 		}
-		_ = os.Setenv("EDITOR", previous)
+		_ = os.Setenv("PATH", previousPath)
 	})
 
-	err := launchProgramEditor(3, "sample.txt")
-	if err == nil {
-		t.Fatal("launchProgramEditor(...) = nil error, want error")
+	if err := launchProgramEditor(3, "sample.txt"); err != nil {
+		t.Fatalf("launchProgramEditor(...) failed: %v", err)
 	}
-	if got, want := err.Error(), "EDITOR is not set"; got != want {
-		t.Fatalf("launchProgramEditor error = %q, want %q", got, want)
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("ReadFile(vi.args) failed: %v", err)
+	}
+	if got, want := string(data), "+3\nsample.txt\n"; got != want {
+		t.Fatalf("vi args = %q, want %q", got, want)
 	}
 }
 

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -2170,7 +2170,7 @@ func TestLaunchProgramEditorDefaultsToVi(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(vi.args) failed: %v", err)
 	}
-	if got, want := string(data), "+3\nsample.txt\n"; got != want {
+	if got, want := strings.ReplaceAll(string(data), "\r\n", "\n"), "+3\nsample.txt\n"; got != want {
 		t.Fatalf("vi args = %q, want %q", got, want)
 	}
 }

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -2129,8 +2129,12 @@ func TestLaunchProgramEditorDefaultsToVi(t *testing.T) {
 	dir := t.TempDir()
 	argsFile := filepath.Join(dir, "vi.args")
 	script := filepath.Join(dir, "vi")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+argsFile+"\n"), 0o755); err != nil {
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > \"$GOLESS_TEST_VI_ARGS\"\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile(vi) failed: %v", err)
+	}
+	batch := filepath.Join(dir, "vi.bat")
+	if err := os.WriteFile(batch, []byte("@echo off\r\n> \"%GOLESS_TEST_VI_ARGS%\" (\r\nfor %%A in (%*) do echo %%~A\r\n)\r\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(vi.bat) failed: %v", err)
 	}
 
 	previous := os.Getenv("EDITOR")
@@ -2138,6 +2142,10 @@ func TestLaunchProgramEditorDefaultsToVi(t *testing.T) {
 		t.Fatalf("Unsetenv(EDITOR) failed: %v", err)
 	}
 	previousPath := os.Getenv("PATH")
+	previousArgsPath := os.Getenv("GOLESS_TEST_VI_ARGS")
+	if err := os.Setenv("GOLESS_TEST_VI_ARGS", argsFile); err != nil {
+		t.Fatalf("Setenv(GOLESS_TEST_VI_ARGS) failed: %v", err)
+	}
 	if err := os.Setenv("PATH", dir+string(os.PathListSeparator)+previousPath); err != nil {
 		t.Fatalf("Setenv(PATH) failed: %v", err)
 	}
@@ -2146,6 +2154,11 @@ func TestLaunchProgramEditorDefaultsToVi(t *testing.T) {
 			_ = os.Unsetenv("EDITOR")
 		} else {
 			_ = os.Setenv("EDITOR", previous)
+		}
+		if previousArgsPath == "" {
+			_ = os.Unsetenv("GOLESS_TEST_VI_ARGS")
+		} else {
+			_ = os.Setenv("GOLESS_TEST_VI_ARGS", previousArgsPath)
 		}
 		_ = os.Setenv("PATH", previousPath)
 	})

--- a/site/content/user-manual/getting-started.md
+++ b/site/content/user-manual/getting-started.md
@@ -25,6 +25,9 @@ printf 'hello\nworld\n' | go run ./cmd/goless -- -
 When `stdout` is redirected or piped, `goless` falls back to pass-through mode
 and writes the selected input unchanged instead of opening the full-screen UI.
 
+When you are viewing a regular file in the full-screen UI, `v` opens that file
+in `$EDITOR` at the current line. Use `-secure` to disable editor launch.
+
 ## What Users Need First
 
 The first user-facing page should answer these questions quickly:


### PR DESCRIPTION
fixes #100

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `v` key to open the current file in the configured $EDITOR at the current line.
  * Added a `-secure` flag to disable launching external programs (disables the `v` editor action).

* **Documentation**
  * Updated help, README, and user manual to document the `v` keybinding and `-secure` behavior and clarify security boundaries.

* **Tests**
  * Added tests for the new flag, keybinding, editor parsing, and secure-mode behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->