### PR TITLE
Configuration file support and theme for the goless command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 /site/public/
 /site/resources/
 /site/.hugo_build.lock
-goless
+/goless
 .superset

--- a/README.md
+++ b/README.md
@@ -342,7 +342,7 @@ Program flags:
 - `--license` to open the bundled Apache license, or print it when stdout is not a terminal
 - `-config path` to load a specific JSON config file instead of the default per-user path
 - `-x n` to set tab width
-- `-preset dark|light|plain|pretty`
+- `-theme dark|light|plain|pretty`
 - `-chrome auto|none|single|rounded`
 - `-hidden`
 - `-live-links`
@@ -367,7 +367,7 @@ The initial config schema is intentionally small:
 
 ```json
 {
-  "preset": "pretty",
+  "theme": "pretty",
   "hidden": false,
   "line-numbers": false,
   "live-links": false,
@@ -376,8 +376,8 @@ The initial config schema is intentionally small:
 ```
 
 CLI flags still take precedence over config values, so
-`goless -config ./alt.json -preset dark file.txt` overrides the selected config
-file's `"preset"` value for that invocation.
+`goless -config ./alt.json -theme dark file.txt` overrides the selected config
+file's `"theme"` value for that invocation.
 
 The default key group is intentionally less-like. Common bindings include:
 
@@ -393,7 +393,7 @@ The default key group is intentionally less-like. Common bindings include:
 - `n` and `N` to repeat search
 - `F2` to cycle search case mode in the bundled key group
 - `F3` to cycle substring, whole-word, and regex matching in the bundled key group
-- `F4` to cycle visual presets in the standalone program
+- `F4` to cycle visual themes in the standalone program
 - `F5` to toggle hidden-character markers in the standalone program
 - `:` then a number to jump to a line
 - `:50%` to jump near the middle of the document

--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Program flags:
 - `-i` for smart-case search behavior
 - `-I` for case-insensitive search behavior
 - `--license` to open the bundled Apache license, or print it when stdout is not a terminal
+- `-config path` to load a specific JSON config file instead of the default per-user path
 - `-x n` to set tab width
 - `-preset dark|light|plain|pretty`
 - `-chrome auto|none|single|rounded`
@@ -350,6 +351,33 @@ Program flags:
 - `-title text`
 - optional `+line` or `+/pattern` startup directive before paths
 - `-` as an explicit stdin path
+
+When present, `goless` also loads per-user configuration from
+`goless/config.json` under the OS config directory returned by
+`os.UserConfigDir()`; on most Linux systems that means
+`$XDG_CONFIG_HOME/goless/config.json` or `~/.config/goless/config.json`.
+
+Config selection precedence is:
+
+1. `-config path`
+2. `GOLESS_CONFIG`
+3. the default per-user config path
+
+The initial config schema is intentionally small:
+
+```json
+{
+  "preset": "pretty",
+  "hidden": false,
+  "line-numbers": false,
+  "live-links": false,
+  "secure": false
+}
+```
+
+CLI flags still take precedence over config values, so
+`goless -config ./alt.json -preset dark file.txt` overrides the selected config
+file's `"preset"` value for that invocation.
 
 The default key group is intentionally less-like. Common bindings include:
 

--- a/cmd/goless/config.go
+++ b/cmd/goless/config.go
@@ -17,8 +17,8 @@ type programConfig struct {
 	Hidden      *bool  `json:"hidden"`
 	LineNumbers *bool  `json:"line-numbers"`
 	LiveLinks   *bool  `json:"live-links"`
-	Preset      string `json:"preset"`
 	Secure      *bool  `json:"secure"`
+	Theme       string `json:"theme"`
 }
 
 func defaultProgramConfigPath() (string, error) {
@@ -84,8 +84,8 @@ func loadProgramConfigAtPath(path string, optional bool) (programConfig, error) 
 		}
 		return programConfig{}, fmt.Errorf("parse config %q: %w", path, err)
 	}
-	if cfg.Preset != "" {
-		if _, err := programPreset(cfg.Preset); err != nil {
+	if cfg.Theme != "" {
+		if _, err := programPreset(cfg.Theme); err != nil {
 			return programConfig{}, fmt.Errorf("parse config %q: %w", path, err)
 		}
 	}
@@ -105,8 +105,8 @@ func applyProgramConfig(opts programOptions, cfg programConfig) programOptions {
 	if cfg.Secure != nil {
 		opts.secure = *cfg.Secure
 	}
-	if cfg.Preset != "" {
-		opts.presetName = cfg.Preset
+	if cfg.Theme != "" {
+		opts.presetName = cfg.Theme
 	}
 	return opts
 }

--- a/cmd/goless/config.go
+++ b/cmd/goless/config.go
@@ -1,0 +1,112 @@
+// Copyright 2026 Garrett D'Amore
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+type programConfig struct {
+	Hidden      *bool  `json:"hidden"`
+	LineNumbers *bool  `json:"line-numbers"`
+	LiveLinks   *bool  `json:"live-links"`
+	Preset      string `json:"preset"`
+	Secure      *bool  `json:"secure"`
+}
+
+func defaultProgramConfigPath() (string, error) {
+	dir, err := os.UserConfigDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "goless", "config.json"), nil
+}
+
+func envProgramConfigPath() string {
+	return os.Getenv("GOLESS_CONFIG")
+}
+
+func programConfigPath() (string, bool, error) {
+	if path := envProgramConfigPath(); path != "" {
+		return path, false, nil
+	}
+	path, err := defaultProgramConfigPath()
+	if err != nil {
+		return "", false, err
+	}
+	return path, true, nil
+}
+
+func loadDefaultProgramConfig() (programConfig, string, error) {
+	path, optional, err := programConfigPath()
+	if err != nil {
+		return programConfig{}, "", nil
+	}
+	cfg, err := loadProgramConfigAtPath(path, optional)
+	return cfg, path, err
+}
+
+func loadRequiredProgramConfig(path string) (programConfig, error) {
+	return loadProgramConfigAtPath(path, false)
+}
+
+func loadProgramConfigAtPath(path string, optional bool) (programConfig, error) {
+	if path == "" {
+		return programConfig{}, nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if optional && errors.Is(err, os.ErrNotExist) {
+			return programConfig{}, nil
+		}
+		return programConfig{}, fmt.Errorf("read config %q: %w", path, err)
+	}
+	if len(bytes.TrimSpace(data)) == 0 {
+		return programConfig{}, nil
+	}
+
+	var cfg programConfig
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&cfg); err != nil {
+		return programConfig{}, fmt.Errorf("parse config %q: %w", path, err)
+	}
+	if err := decoder.Decode(&struct{}{}); err != io.EOF {
+		if err == nil {
+			return programConfig{}, fmt.Errorf("parse config %q: unexpected trailing content", path)
+		}
+		return programConfig{}, fmt.Errorf("parse config %q: %w", path, err)
+	}
+	if cfg.Preset != "" {
+		if _, err := programPreset(cfg.Preset); err != nil {
+			return programConfig{}, fmt.Errorf("parse config %q: %w", path, err)
+		}
+	}
+	return cfg, nil
+}
+
+func applyProgramConfig(opts programOptions, cfg programConfig) programOptions {
+	if cfg.Hidden != nil {
+		opts.hidden = *cfg.Hidden
+	}
+	if cfg.LineNumbers != nil {
+		opts.lineNumbers = *cfg.LineNumbers
+	}
+	if cfg.LiveLinks != nil {
+		opts.liveLinks = *cfg.LiveLinks
+	}
+	if cfg.Secure != nil {
+		opts.secure = *cfg.Secure
+	}
+	if cfg.Preset != "" {
+		opts.presetName = cfg.Preset
+	}
+	return opts
+}

--- a/cmd/goless/config_test.go
+++ b/cmd/goless/config_test.go
@@ -1,0 +1,262 @@
+// Copyright 2026 Garrett D'Amore
+// SPDX-License-Identifier: Apache-2.0
+
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadProgramConfigMissing(t *testing.T) {
+	cfg, err := loadProgramConfigAtPath(filepath.Join(t.TempDir(), "missing.json"), true)
+	if err != nil {
+		t.Fatalf("loadProgramConfig(missing) failed: %v", err)
+	}
+	if cfg != (programConfig{}) {
+		t.Fatalf("loadProgramConfig(missing) = %+v, want zero config", cfg)
+	}
+}
+
+func TestLoadProgramConfigRejectsUnknownFields(t *testing.T) {
+	path := writeTestProgramConfig(t, `{"bogus":true}`)
+
+	_, err := loadProgramConfigAtPath(path, true)
+	if err == nil {
+		t.Fatal("loadProgramConfig(...) = nil error, want parse error")
+	}
+	if !strings.Contains(err.Error(), "bogus") {
+		t.Fatalf("loadProgramConfig(...) error = %q, want unknown field detail", err)
+	}
+}
+
+func TestLoadProgramConfigRejectsInvalidPreset(t *testing.T) {
+	path := writeTestProgramConfig(t, `{"preset":"bogus"}`)
+
+	_, err := loadProgramConfigAtPath(path, true)
+	if err == nil {
+		t.Fatal("loadProgramConfig(...) = nil error, want preset validation error")
+	}
+	if !strings.Contains(err.Error(), "unknown preset") {
+		t.Fatalf("loadProgramConfig(...) error = %q, want preset validation detail", err)
+	}
+}
+
+func TestParseProgramFlagsLoadsDefaultProgramConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+	writeDefaultTestProgramConfig(t, `{"preset":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
+
+	var out bytes.Buffer
+	opts, args, err := parseProgramFlags([]string{"sample.txt"}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(...) failed: %v", err)
+	}
+	if got, want := opts.presetName, "dark"; got != want {
+		t.Fatalf("preset = %q, want %q", got, want)
+	}
+	if !opts.hidden {
+		t.Fatal("hidden = false, want true from config")
+	}
+	if !opts.lineNumbers {
+		t.Fatal("lineNumbers = false, want true from config")
+	}
+	if !opts.liveLinks {
+		t.Fatal("liveLinks = false, want true from config")
+	}
+	if !opts.secure {
+		t.Fatal("secure = false, want true from config")
+	}
+	if got, want := len(args), 1; got != want {
+		t.Fatalf("len(args) = %d, want %d", got, want)
+	}
+}
+
+func TestParseProgramFlagsCLIOverridesProgramConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+	writeDefaultTestProgramConfig(t, `{"preset":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
+
+	var out bytes.Buffer
+	opts, _, err := parseProgramFlags([]string{"-preset", "light", "-N=false", "-hidden=false", "-live-links=false", "-secure=false"}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(...) failed: %v", err)
+	}
+	if got, want := opts.presetName, "light"; got != want {
+		t.Fatalf("preset = %q, want %q", got, want)
+	}
+	if opts.hidden {
+		t.Fatal("hidden = true, want CLI override false")
+	}
+	if opts.lineNumbers {
+		t.Fatal("lineNumbers = true, want CLI override false")
+	}
+	if opts.liveLinks {
+		t.Fatal("liveLinks = true, want CLI override false")
+	}
+	if opts.secure {
+		t.Fatal("secure = true, want CLI override false")
+	}
+}
+
+func TestParseProgramFlagsExplicitConfigOverridesDefaultPath(t *testing.T) {
+	setTestProgramConfigHome(t)
+	writeDefaultTestProgramConfig(t, `{"preset":"dark","line-numbers":true}`)
+	explicitPath := writeTestProgramConfig(t, `{"preset":"light","hidden":true}`)
+
+	var out bytes.Buffer
+	opts, _, err := parseProgramFlags([]string{"-config", explicitPath}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(...) failed: %v", err)
+	}
+	if got, want := opts.configPath, explicitPath; got != want {
+		t.Fatalf("configPath = %q, want %q", got, want)
+	}
+	if got, want := opts.presetName, "light"; got != want {
+		t.Fatalf("preset = %q, want %q", got, want)
+	}
+	if !opts.hidden {
+		t.Fatal("hidden = false, want true from explicit config")
+	}
+	if opts.lineNumbers {
+		t.Fatal("lineNumbers = true, want false because explicit config replaces default config source")
+	}
+}
+
+func TestParseProgramFlagsLoadsEnvProgramConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+	envPath := writeTestProgramConfig(t, `{"preset":"light","hidden":true,"line-numbers":true}`)
+	t.Setenv("GOLESS_CONFIG", envPath)
+
+	var out bytes.Buffer
+	opts, _, err := parseProgramFlags([]string{"sample.txt"}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(...) failed: %v", err)
+	}
+	if got, want := opts.configPath, envPath; got != want {
+		t.Fatalf("configPath = %q, want %q", got, want)
+	}
+	if got, want := opts.presetName, "light"; got != want {
+		t.Fatalf("preset = %q, want %q", got, want)
+	}
+	if !opts.hidden {
+		t.Fatal("hidden = false, want true from GOLESS_CONFIG")
+	}
+	if !opts.lineNumbers {
+		t.Fatal("lineNumbers = false, want true from GOLESS_CONFIG")
+	}
+}
+
+func TestParseProgramFlagsEnvConfigOverridesDefaultPath(t *testing.T) {
+	setTestProgramConfigHome(t)
+	writeDefaultTestProgramConfig(t, `{"preset":"dark","hidden":false}`)
+	envPath := writeTestProgramConfig(t, `{"preset":"light","hidden":true}`)
+	t.Setenv("GOLESS_CONFIG", envPath)
+
+	var out bytes.Buffer
+	opts, _, err := parseProgramFlags([]string{"sample.txt"}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(...) failed: %v", err)
+	}
+	if got, want := opts.presetName, "light"; got != want {
+		t.Fatalf("preset = %q, want %q", got, want)
+	}
+	if !opts.hidden {
+		t.Fatal("hidden = false, want true from GOLESS_CONFIG")
+	}
+}
+
+func TestParseProgramFlagsExplicitConfigOverridesEnvConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+	envPath := writeTestProgramConfig(t, `{"preset":"dark","hidden":true}`)
+	explicitPath := writeTestProgramConfigAtPath(t, filepath.Join(t.TempDir(), "explicit.json"), `{"preset":"light","hidden":false,"line-numbers":true}`)
+	t.Setenv("GOLESS_CONFIG", envPath)
+
+	var out bytes.Buffer
+	opts, _, err := parseProgramFlags([]string{"-config", explicitPath}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(...) failed: %v", err)
+	}
+	if got, want := opts.configPath, explicitPath; got != want {
+		t.Fatalf("configPath = %q, want %q", got, want)
+	}
+	if got, want := opts.presetName, "light"; got != want {
+		t.Fatalf("preset = %q, want %q", got, want)
+	}
+	if opts.hidden {
+		t.Fatal("hidden = true, want false from explicit config")
+	}
+	if !opts.lineNumbers {
+		t.Fatal("lineNumbers = false, want true from explicit config")
+	}
+}
+
+func TestParseProgramFlagsRejectsMissingExplicitConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+
+	var out bytes.Buffer
+	_, _, err := parseProgramFlags([]string{"-config", filepath.Join(t.TempDir(), "missing.json")}, &out)
+	if err == nil {
+		t.Fatal("parseProgramFlags(-config missing) = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "read config") {
+		t.Fatalf("parseProgramFlags(-config missing) error = %q, want read config detail", err)
+	}
+}
+
+func TestParseProgramFlagsHelpMentionsConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+
+	var out bytes.Buffer
+	opts, args, err := parseProgramFlags([]string{"--help"}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(--help) failed: %v", err)
+	}
+	if !opts.showHelp {
+		t.Fatal("parseProgramFlags(--help) did not set showHelp")
+	}
+	if len(args) != 0 {
+		t.Fatalf("len(args) after --help = %d, want 0", len(args))
+	}
+	if got := out.String(); !strings.Contains(got, "GOLESS_CONFIG") {
+		t.Fatalf("help output = %q, want config path note", got)
+	}
+}
+
+func setTestProgramConfigHome(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
+}
+
+func writeDefaultTestProgramConfig(t *testing.T, body string) string {
+	t.Helper()
+	path, err := defaultProgramConfigPath()
+	if err != nil {
+		t.Fatalf("defaultProgramConfigPath() failed: %v", err)
+	}
+	return writeProgramConfigFile(t, path, body)
+}
+
+func writeTestProgramConfig(t *testing.T, body string) string {
+	t.Helper()
+	return writeTestProgramConfigAtPath(t, filepath.Join(t.TempDir(), "config.json"), body)
+}
+
+func writeTestProgramConfigAtPath(t *testing.T, path, body string) string {
+	t.Helper()
+	return writeProgramConfigFile(t, path, body)
+}
+
+func writeProgramConfigFile(t *testing.T, path, body string) string {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll(%q) failed: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("WriteFile(%q) failed: %v", path, err)
+	}
+	return path
+}

--- a/cmd/goless/config_test.go
+++ b/cmd/goless/config_test.go
@@ -34,20 +34,20 @@ func TestLoadProgramConfigRejectsUnknownFields(t *testing.T) {
 }
 
 func TestLoadProgramConfigRejectsInvalidPreset(t *testing.T) {
-	path := writeTestProgramConfig(t, `{"preset":"bogus"}`)
+	path := writeTestProgramConfig(t, `{"theme":"bogus"}`)
 
 	_, err := loadProgramConfigAtPath(path, true)
 	if err == nil {
-		t.Fatal("loadProgramConfig(...) = nil error, want preset validation error")
+		t.Fatal("loadProgramConfig(...) = nil error, want theme validation error")
 	}
-	if !strings.Contains(err.Error(), "unknown preset") {
-		t.Fatalf("loadProgramConfig(...) error = %q, want preset validation detail", err)
+	if !strings.Contains(err.Error(), "unknown theme") {
+		t.Fatalf("loadProgramConfig(...) error = %q, want theme validation detail", err)
 	}
 }
 
 func TestParseProgramFlagsLoadsDefaultProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
-	writeDefaultTestProgramConfig(t, `{"preset":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
+	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
 
 	var out bytes.Buffer
 	opts, args, err := parseProgramFlags([]string{"sample.txt"}, &out)
@@ -55,7 +55,7 @@ func TestParseProgramFlagsLoadsDefaultProgramConfig(t *testing.T) {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
 	if got, want := opts.presetName, "dark"; got != want {
-		t.Fatalf("preset = %q, want %q", got, want)
+		t.Fatalf("theme = %q, want %q", got, want)
 	}
 	if !opts.hidden {
 		t.Fatal("hidden = false, want true from config")
@@ -76,15 +76,15 @@ func TestParseProgramFlagsLoadsDefaultProgramConfig(t *testing.T) {
 
 func TestParseProgramFlagsCLIOverridesProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
-	writeDefaultTestProgramConfig(t, `{"preset":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
+	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
 
 	var out bytes.Buffer
-	opts, _, err := parseProgramFlags([]string{"-preset", "light", "-N=false", "-hidden=false", "-live-links=false", "-secure=false"}, &out)
+	opts, _, err := parseProgramFlags([]string{"-theme", "light", "-N=false", "-hidden=false", "-live-links=false", "-secure=false"}, &out)
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
 	if got, want := opts.presetName, "light"; got != want {
-		t.Fatalf("preset = %q, want %q", got, want)
+		t.Fatalf("theme = %q, want %q", got, want)
 	}
 	if opts.hidden {
 		t.Fatal("hidden = true, want CLI override false")
@@ -102,8 +102,8 @@ func TestParseProgramFlagsCLIOverridesProgramConfig(t *testing.T) {
 
 func TestParseProgramFlagsExplicitConfigOverridesDefaultPath(t *testing.T) {
 	setTestProgramConfigHome(t)
-	writeDefaultTestProgramConfig(t, `{"preset":"dark","line-numbers":true}`)
-	explicitPath := writeTestProgramConfig(t, `{"preset":"light","hidden":true}`)
+	writeDefaultTestProgramConfig(t, `{"theme":"dark","line-numbers":true}`)
+	explicitPath := writeTestProgramConfig(t, `{"theme":"light","hidden":true}`)
 
 	var out bytes.Buffer
 	opts, _, err := parseProgramFlags([]string{"-config", explicitPath}, &out)
@@ -114,7 +114,7 @@ func TestParseProgramFlagsExplicitConfigOverridesDefaultPath(t *testing.T) {
 		t.Fatalf("configPath = %q, want %q", got, want)
 	}
 	if got, want := opts.presetName, "light"; got != want {
-		t.Fatalf("preset = %q, want %q", got, want)
+		t.Fatalf("theme = %q, want %q", got, want)
 	}
 	if !opts.hidden {
 		t.Fatal("hidden = false, want true from explicit config")
@@ -126,7 +126,7 @@ func TestParseProgramFlagsExplicitConfigOverridesDefaultPath(t *testing.T) {
 
 func TestParseProgramFlagsLoadsEnvProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
-	envPath := writeTestProgramConfig(t, `{"preset":"light","hidden":true,"line-numbers":true}`)
+	envPath := writeTestProgramConfig(t, `{"theme":"light","hidden":true,"line-numbers":true}`)
 	t.Setenv("GOLESS_CONFIG", envPath)
 
 	var out bytes.Buffer
@@ -138,7 +138,7 @@ func TestParseProgramFlagsLoadsEnvProgramConfig(t *testing.T) {
 		t.Fatalf("configPath = %q, want %q", got, want)
 	}
 	if got, want := opts.presetName, "light"; got != want {
-		t.Fatalf("preset = %q, want %q", got, want)
+		t.Fatalf("theme = %q, want %q", got, want)
 	}
 	if !opts.hidden {
 		t.Fatal("hidden = false, want true from GOLESS_CONFIG")
@@ -150,8 +150,8 @@ func TestParseProgramFlagsLoadsEnvProgramConfig(t *testing.T) {
 
 func TestParseProgramFlagsEnvConfigOverridesDefaultPath(t *testing.T) {
 	setTestProgramConfigHome(t)
-	writeDefaultTestProgramConfig(t, `{"preset":"dark","hidden":false}`)
-	envPath := writeTestProgramConfig(t, `{"preset":"light","hidden":true}`)
+	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":false}`)
+	envPath := writeTestProgramConfig(t, `{"theme":"light","hidden":true}`)
 	t.Setenv("GOLESS_CONFIG", envPath)
 
 	var out bytes.Buffer
@@ -160,7 +160,7 @@ func TestParseProgramFlagsEnvConfigOverridesDefaultPath(t *testing.T) {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
 	if got, want := opts.presetName, "light"; got != want {
-		t.Fatalf("preset = %q, want %q", got, want)
+		t.Fatalf("theme = %q, want %q", got, want)
 	}
 	if !opts.hidden {
 		t.Fatal("hidden = false, want true from GOLESS_CONFIG")
@@ -169,8 +169,8 @@ func TestParseProgramFlagsEnvConfigOverridesDefaultPath(t *testing.T) {
 
 func TestParseProgramFlagsExplicitConfigOverridesEnvConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
-	envPath := writeTestProgramConfig(t, `{"preset":"dark","hidden":true}`)
-	explicitPath := writeTestProgramConfigAtPath(t, filepath.Join(t.TempDir(), "explicit.json"), `{"preset":"light","hidden":false,"line-numbers":true}`)
+	envPath := writeTestProgramConfig(t, `{"theme":"dark","hidden":true}`)
+	explicitPath := writeTestProgramConfigAtPath(t, filepath.Join(t.TempDir(), "explicit.json"), `{"theme":"light","hidden":false,"line-numbers":true}`)
 	t.Setenv("GOLESS_CONFIG", envPath)
 
 	var out bytes.Buffer
@@ -182,7 +182,7 @@ func TestParseProgramFlagsExplicitConfigOverridesEnvConfig(t *testing.T) {
 		t.Fatalf("configPath = %q, want %q", got, want)
 	}
 	if got, want := opts.presetName, "light"; got != want {
-		t.Fatalf("preset = %q, want %q", got, want)
+		t.Fatalf("theme = %q, want %q", got, want)
 	}
 	if opts.hidden {
 		t.Fatal("hidden = true, want false from explicit config")

--- a/cmd/goless/config_test.go
+++ b/cmd/goless/config_test.go
@@ -21,6 +21,28 @@ func TestLoadProgramConfigMissing(t *testing.T) {
 	}
 }
 
+func TestLoadProgramConfigEmptyPath(t *testing.T) {
+	cfg, err := loadProgramConfigAtPath("", true)
+	if err != nil {
+		t.Fatalf("loadProgramConfigAtPath(empty) failed: %v", err)
+	}
+	if cfg != (programConfig{}) {
+		t.Fatalf("loadProgramConfigAtPath(empty) = %+v, want zero config", cfg)
+	}
+}
+
+func TestLoadProgramConfigBlankFile(t *testing.T) {
+	path := writeTestProgramConfig(t, "\n\t  \n")
+
+	cfg, err := loadProgramConfigAtPath(path, true)
+	if err != nil {
+		t.Fatalf("loadProgramConfigAtPath(blank file) failed: %v", err)
+	}
+	if cfg != (programConfig{}) {
+		t.Fatalf("loadProgramConfigAtPath(blank file) = %+v, want zero config", cfg)
+	}
+}
+
 func TestLoadProgramConfigRejectsUnknownFields(t *testing.T) {
 	path := writeTestProgramConfig(t, `{"bogus":true}`)
 
@@ -42,6 +64,18 @@ func TestLoadProgramConfigRejectsInvalidPreset(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "unknown theme") {
 		t.Fatalf("loadProgramConfig(...) error = %q, want theme validation detail", err)
+	}
+}
+
+func TestLoadProgramConfigRejectsTrailingContent(t *testing.T) {
+	path := writeTestProgramConfig(t, "{\"theme\":\"dark\"}\n{}\n")
+
+	_, err := loadProgramConfigAtPath(path, true)
+	if err == nil {
+		t.Fatal("loadProgramConfig(...) = nil error, want trailing content error")
+	}
+	if !strings.Contains(err.Error(), "unexpected trailing content") {
+		t.Fatalf("loadProgramConfig(...) error = %q, want trailing content detail", err)
 	}
 }
 
@@ -205,6 +239,151 @@ func TestParseProgramFlagsRejectsMissingExplicitConfig(t *testing.T) {
 	}
 }
 
+func TestParseProgramFlagsHelpSkipsBrokenDefaultProgramConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+	writeDefaultTestProgramConfig(t, `{"theme":"dark"`)
+
+	var out bytes.Buffer
+	opts, args, err := parseProgramFlags([]string{"--help"}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(--help) failed: %v", err)
+	}
+	if !opts.showHelp {
+		t.Fatal("parseProgramFlags(--help) did not set showHelp")
+	}
+	if len(args) != 0 {
+		t.Fatalf("len(args) after --help = %d, want 0", len(args))
+	}
+}
+
+func TestParseProgramFlagsVersionSkipsBrokenEnvProgramConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+	path := writeTestProgramConfig(t, `{"theme":"dark"`)
+	t.Setenv("GOLESS_CONFIG", path)
+
+	var out bytes.Buffer
+	opts, args, err := parseProgramFlags([]string{"--version"}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(--version) failed: %v", err)
+	}
+	if !opts.version {
+		t.Fatal("parseProgramFlags(--version) did not set version")
+	}
+	if len(args) != 0 {
+		t.Fatalf("len(args) after --version = %d, want 0", len(args))
+	}
+}
+
+func TestParseProgramFlagsHelpSkipsBrokenExplicitProgramConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+	path := writeTestProgramConfig(t, `{"theme":"dark"`)
+
+	var out bytes.Buffer
+	opts, args, err := parseProgramFlags([]string{"--help", "-config", path}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(--help, -config) failed: %v", err)
+	}
+	if !opts.showHelp {
+		t.Fatal("parseProgramFlags(--help, -config) did not set showHelp")
+	}
+	if len(args) != 0 {
+		t.Fatalf("len(args) after --help = %d, want 0", len(args))
+	}
+}
+
+func TestParseProgramFlagsVersionSkipsBrokenExplicitProgramConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+	path := writeTestProgramConfig(t, `{"theme":"dark"`)
+
+	var out bytes.Buffer
+	opts, args, err := parseProgramFlags([]string{"--version", "-config", path}, &out)
+	if err != nil {
+		t.Fatalf("parseProgramFlags(--version, -config) failed: %v", err)
+	}
+	if !opts.version {
+		t.Fatal("parseProgramFlags(--version, -config) did not set version")
+	}
+	if len(args) != 0 {
+		t.Fatalf("len(args) after --version = %d, want 0", len(args))
+	}
+}
+
+func TestProgramHasImmediateExitFlag(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{name: "none", args: []string{"sample.txt"}, want: false},
+		{name: "help long", args: []string{"--help"}, want: true},
+		{name: "help short", args: []string{"-h"}, want: true},
+		{name: "help question", args: []string{"-?"}, want: true},
+		{name: "version long", args: []string{"--version"}, want: true},
+		{name: "version short", args: []string{"-version"}, want: true},
+		{name: "help explicit true", args: []string{"--help=true"}, want: true},
+		{name: "version explicit true", args: []string{"--version=true"}, want: true},
+		{name: "help explicit false", args: []string{"--help=false"}, want: false},
+		{name: "stops at double dash", args: []string{"--", "--help"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := programHasImmediateExitFlag(tt.args); got != tt.want {
+				t.Fatalf("programHasImmediateExitFlag(%v) = %v, want %v", tt.args, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProgramConfigPathFromArgsRejectsEmptyValue(t *testing.T) {
+	tests := []struct {
+		name string
+		args []string
+	}{
+		{name: "separate arg", args: []string{"-config", ""}},
+		{name: "inline short", args: []string{"-config="}},
+		{name: "inline long", args: []string{"--config="}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, _, err := programConfigPathFromArgs(tt.args)
+			if err == nil {
+				t.Fatal("programConfigPathFromArgs(...) = nil error, want error")
+			}
+			if !strings.Contains(err.Error(), "non-empty argument") {
+				t.Fatalf("programConfigPathFromArgs(...) error = %q, want non-empty argument detail", err)
+			}
+		})
+	}
+}
+
+func TestProgramConfigPathFromArgsUsesLastExplicitConfig(t *testing.T) {
+	got, explicit, err := programConfigPathFromArgs([]string{"-config", "first.json", "--config=second.json"})
+	if err != nil {
+		t.Fatalf("programConfigPathFromArgs(...) failed: %v", err)
+	}
+	if !explicit {
+		t.Fatal("programConfigPathFromArgs(...) explicit = false, want true")
+	}
+	if want := "second.json"; got != want {
+		t.Fatalf("programConfigPathFromArgs(...) path = %q, want %q", got, want)
+	}
+}
+
+func TestProgramConfigPathFromArgsStopsAtDoubleDash(t *testing.T) {
+	got, explicit, err := programConfigPathFromArgs([]string{"--", "-config", "ignored.json"})
+	if err != nil {
+		t.Fatalf("programConfigPathFromArgs(...) failed: %v", err)
+	}
+	if explicit {
+		t.Fatal("programConfigPathFromArgs(...) explicit = true, want false")
+	}
+	if got != "" {
+		t.Fatalf("programConfigPathFromArgs(...) path = %q, want empty", got)
+	}
+}
+
 func TestParseProgramFlagsHelpMentionsConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
 
@@ -228,6 +407,7 @@ func setTestProgramConfigHome(t *testing.T) {
 	t.Helper()
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
+	t.Setenv("APPDATA", filepath.Join(dir, "AppData", "Roaming"))
 	t.Setenv("XDG_CONFIG_HOME", filepath.Join(dir, ".config"))
 }
 

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -36,6 +36,7 @@ const programFileFollowInterval = 250 * time.Millisecond
 
 type programOptions struct {
 	chromeName        string
+	configPath        string
 	hidden            bool
 	ignoredChopLines  bool
 	ignoredRawControl bool
@@ -76,12 +77,12 @@ type programFileFollower struct {
 }
 
 var (
-	programScreenFactory            = newProgramScreen
-	programStdinIsTerminalFunc      = stdinIsTerminal
-	programStdoutIsTerminalFunc     = stdoutIsTerminal
-	programDefaultScreenFactory     = tcell.NewScreen
-	programTerminfoScreenFactory    = tcell.NewTerminfoScreen
-	programEditorLauncher           = launchProgramEditor
+	programScreenFactory         = newProgramScreen
+	programStdinIsTerminalFunc   = stdinIsTerminal
+	programStdoutIsTerminalFunc  = stdoutIsTerminal
+	programDefaultScreenFactory  = tcell.NewScreen
+	programTerminfoScreenFactory = tcell.NewTerminfoScreen
+	programEditorLauncher        = launchProgramEditor
 )
 
 func main() {
@@ -420,36 +421,54 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 		searchCaseMode: goless.SearchSmartCase,
 		tabWidth:       8,
 	}
+	configPath, hasExplicitConfigPath, err := programConfigPathFromArgs(args)
+	if err != nil {
+		return programOptions{}, nil, err
+	}
+
+	var cfg programConfig
+	if hasExplicitConfigPath {
+		opts.configPath = configPath
+		cfg, err = loadRequiredProgramConfig(configPath)
+	} else {
+		cfg, opts.configPath, err = loadDefaultProgramConfig()
+	}
+	if err != nil {
+		return programOptions{}, nil, err
+	}
+	opts = applyProgramConfig(opts, cfg)
 
 	fs := flag.NewFlagSet("goless", flag.ContinueOnError)
 	fs.SetOutput(output)
 	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "usage: goless [-?|-e|-E|-F|-N|-R|-S|-i|-I|-s|-secure] [-x n] [-preset dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [-license] [+line|+/pattern] [-version] [path ...]\n")
+		fmt.Fprintf(fs.Output(), "usage: goless [-?|-e|-E|-F|-N|-R|-S|-i|-I|-s|-secure] [-x n] [-config path] [-preset dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [-license] [+line|+/pattern] [-version] [path ...]\n")
+		fmt.Fprintln(fs.Output(), "config: goless loads GOLESS_CONFIG when set, otherwise goless/config.json from the per-user config directory; -config overrides both")
 	}
 
-	fs.BoolVar(&opts.showHelp, "?", false, "show help")
-	fs.BoolVar(&opts.showHelp, "help", false, "show help")
-	fs.BoolVar(&opts.showHelp, "h", false, "show help")
-	fs.BoolVar(&opts.showLicense, "license", false, "show the bundled Apache license")
-	fs.BoolVar(&opts.quitAtEOF, "e", false, "quit on the first forward command at EOF")
-	fs.BoolVar(&opts.quitAtEOFFirst, "E", false, "quit when EOF is already visible on screen")
-	fs.BoolVar(&opts.quitIfOneScreen, "F", false, "quit if the entire input fits on one screen")
-	fs.BoolVar(&opts.lineNumbers, "N", false, "show line numbers")
-	fs.BoolVar(&opts.ignoredRawControl, "R", false, "accepted as a less compatibility no-op")
-	fs.BoolVar(&opts.ignoredChopLines, "S", false, "accepted as a less compatibility no-op")
-	fs.BoolVar(&opts.hidden, "hidden", false, "show tabs, line endings, carriage returns, and EOF markers")
-	fs.BoolVar(&opts.liveLinks, "live-links", false, "enable live OSC 8 hyperlinks in the program")
-	fs.BoolVar(&opts.quitAtEOF, "quit-at-eof", false, "long form of -e")
-	fs.BoolVar(&opts.quitAtEOFFirst, "QUIT-AT-EOF", false, "long form of -E")
-	fs.BoolVar(&opts.secure, "secure", false, "disable standalone commands that launch external programs")
-	fs.BoolVar(&opts.squeeze, "s", false, "collapse repeated blank lines in the current view")
-	fs.BoolVar(&opts.squeeze, "squeeze", false, "collapse repeated blank lines in the current view")
-	fs.StringVar(&opts.presetName, "preset", "pretty", "visual preset: none, dark, light, plain, pretty")
-	fs.StringVar(&opts.chromeName, "chrome", "auto", "chrome override: auto, none, single, rounded")
-	fs.StringVar(&opts.renderName, "render", "hybrid", "render mode: hybrid, literal, presentation")
-	fs.StringVar(&opts.title, "title", "", "frame title")
-	fs.IntVar(&opts.tabWidth, "x", 8, "tab width")
-	fs.BoolVar(&opts.version, "version", false, "display program version and exit")
+	fs.BoolVar(&opts.showHelp, "?", opts.showHelp, "show help")
+	fs.BoolVar(&opts.showHelp, "help", opts.showHelp, "show help")
+	fs.BoolVar(&opts.showHelp, "h", opts.showHelp, "show help")
+	fs.BoolVar(&opts.showLicense, "license", opts.showLicense, "show the bundled Apache license")
+	fs.BoolVar(&opts.quitAtEOF, "e", opts.quitAtEOF, "quit on the first forward command at EOF")
+	fs.BoolVar(&opts.quitAtEOFFirst, "E", opts.quitAtEOFFirst, "quit when EOF is already visible on screen")
+	fs.BoolVar(&opts.quitIfOneScreen, "F", opts.quitIfOneScreen, "quit if the entire input fits on one screen")
+	fs.BoolVar(&opts.lineNumbers, "N", opts.lineNumbers, "show line numbers")
+	fs.BoolVar(&opts.ignoredRawControl, "R", opts.ignoredRawControl, "accepted as a less compatibility no-op")
+	fs.BoolVar(&opts.ignoredChopLines, "S", opts.ignoredChopLines, "accepted as a less compatibility no-op")
+	fs.BoolVar(&opts.hidden, "hidden", opts.hidden, "show tabs, line endings, carriage returns, and EOF markers")
+	fs.BoolVar(&opts.liveLinks, "live-links", opts.liveLinks, "enable live OSC 8 hyperlinks in the program")
+	fs.BoolVar(&opts.quitAtEOF, "quit-at-eof", opts.quitAtEOF, "long form of -e")
+	fs.BoolVar(&opts.quitAtEOFFirst, "QUIT-AT-EOF", opts.quitAtEOFFirst, "long form of -E")
+	fs.BoolVar(&opts.secure, "secure", opts.secure, "disable standalone commands that launch external programs")
+	fs.BoolVar(&opts.squeeze, "s", opts.squeeze, "collapse repeated blank lines in the current view")
+	fs.BoolVar(&opts.squeeze, "squeeze", opts.squeeze, "collapse repeated blank lines in the current view")
+	fs.StringVar(&opts.configPath, "config", opts.configPath, "path to a JSON config file")
+	fs.StringVar(&opts.presetName, "preset", opts.presetName, "visual preset: none, dark, light, plain, pretty")
+	fs.StringVar(&opts.chromeName, "chrome", opts.chromeName, "chrome override: auto, none, single, rounded")
+	fs.StringVar(&opts.renderName, "render", opts.renderName, "render mode: hybrid, literal, presentation")
+	fs.StringVar(&opts.title, "title", opts.title, "frame title")
+	fs.IntVar(&opts.tabWidth, "x", opts.tabWidth, "tab width")
+	fs.BoolVar(&opts.version, "version", opts.version, "display program version and exit")
 
 	var ignoreSmartCase bool
 	var ignoreCase bool
@@ -483,6 +502,30 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 		}
 	}
 	return opts, fs.Args(), nil
+}
+
+func programConfigPathFromArgs(args []string) (string, bool, error) {
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		switch {
+		case arg == "--":
+			return "", false, nil
+		case arg == "-config" || arg == "--config":
+			if i+1 >= len(args) {
+				return "", false, fmt.Errorf("flag needs an argument: %s", arg)
+			}
+			return args[i+1], true, nil
+		case strings.HasPrefix(arg, "-config="):
+			return strings.TrimPrefix(arg, "-config="), true, nil
+		case strings.HasPrefix(arg, "--config="):
+			return strings.TrimPrefix(arg, "--config="), true, nil
+		case strings.HasPrefix(arg, "-"):
+			continue
+		default:
+			return "", false, nil
+		}
+	}
+	return "", false, nil
 }
 
 func programQuitAtEOFPolicyFromFlags(quitAtEOF, quitAtEOFFirst bool) programQuitAtEOFPolicy {

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -421,22 +421,24 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 		searchCaseMode: goless.SearchSmartCase,
 		tabWidth:       8,
 	}
-	configPath, hasExplicitConfigPath, err := programConfigPathFromArgs(args)
-	if err != nil {
-		return programOptions{}, nil, err
-	}
+	if !programHasImmediateExitFlag(args) {
+		configPath, hasExplicitConfigPath, err := programConfigPathFromArgs(args)
+		if err != nil {
+			return programOptions{}, nil, err
+		}
 
-	var cfg programConfig
-	if hasExplicitConfigPath {
-		opts.configPath = configPath
-		cfg, err = loadRequiredProgramConfig(configPath)
-	} else {
-		cfg, opts.configPath, err = loadDefaultProgramConfig()
+		var cfg programConfig
+		if hasExplicitConfigPath {
+			opts.configPath = configPath
+			cfg, err = loadRequiredProgramConfig(configPath)
+		} else {
+			cfg, opts.configPath, err = loadDefaultProgramConfig()
+		}
+		if err != nil {
+			return programOptions{}, nil, err
+		}
+		opts = applyProgramConfig(opts, cfg)
 	}
-	if err != nil {
-		return programOptions{}, nil, err
-	}
-	opts = applyProgramConfig(opts, cfg)
 
 	fs := flag.NewFlagSet("goless", flag.ContinueOnError)
 	fs.SetOutput(output)
@@ -504,28 +506,61 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 	return opts, fs.Args(), nil
 }
 
+func programHasImmediateExitFlag(args []string) bool {
+	for _, arg := range args {
+		if arg == "--" {
+			return false
+		}
+		name, value, hasValue := strings.Cut(arg, "=")
+		switch name {
+		case "-?", "-h", "--help":
+			return !hasValue || value == "true"
+		case "-version", "--version":
+			return !hasValue || value == "true"
+		}
+	}
+	return false
+}
+
 func programConfigPathFromArgs(args []string) (string, bool, error) {
+	var (
+		path     string
+		explicit bool
+	)
 	for i := 0; i < len(args); i++ {
 		arg := args[i]
 		switch {
 		case arg == "--":
-			return "", false, nil
+			return path, explicit, nil
 		case arg == "-config" || arg == "--config":
 			if i+1 >= len(args) {
 				return "", false, fmt.Errorf("flag needs an argument: %s", arg)
 			}
-			return args[i+1], true, nil
+			if args[i+1] == "" {
+				return "", false, fmt.Errorf("flag needs a non-empty argument: %s", arg)
+			}
+			path = args[i+1]
+			explicit = true
+			i++
 		case strings.HasPrefix(arg, "-config="):
-			return strings.TrimPrefix(arg, "-config="), true, nil
+			path = strings.TrimPrefix(arg, "-config=")
+			if path == "" {
+				return "", false, fmt.Errorf("flag needs a non-empty argument: -config")
+			}
+			explicit = true
 		case strings.HasPrefix(arg, "--config="):
-			return strings.TrimPrefix(arg, "--config="), true, nil
+			path = strings.TrimPrefix(arg, "--config=")
+			if path == "" {
+				return "", false, fmt.Errorf("flag needs a non-empty argument: --config")
+			}
+			explicit = true
 		case strings.HasPrefix(arg, "-"):
 			continue
 		default:
-			return "", false, nil
+			return path, explicit, nil
 		}
 	}
-	return "", false, nil
+	return path, explicit, nil
 }
 
 func programQuitAtEOFPolicyFromFlags(quitAtEOF, quitAtEOFFirst bool) programQuitAtEOFPolicy {

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -441,7 +441,7 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 	fs := flag.NewFlagSet("goless", flag.ContinueOnError)
 	fs.SetOutput(output)
 	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "usage: goless [-?|-e|-E|-F|-N|-R|-S|-i|-I|-s|-secure] [-x n] [-config path] [-preset dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [-license] [+line|+/pattern] [-version] [path ...]\n")
+		fmt.Fprintf(fs.Output(), "usage: goless [-?|-e|-E|-F|-N|-R|-S|-i|-I|-s|-secure] [-x n] [-config path] [-theme dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [-license] [+line|+/pattern] [-version] [path ...]\n")
 		fmt.Fprintln(fs.Output(), "config: goless loads GOLESS_CONFIG when set, otherwise goless/config.json from the per-user config directory; -config overrides both")
 	}
 
@@ -463,7 +463,7 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 	fs.BoolVar(&opts.squeeze, "s", opts.squeeze, "collapse repeated blank lines in the current view")
 	fs.BoolVar(&opts.squeeze, "squeeze", opts.squeeze, "collapse repeated blank lines in the current view")
 	fs.StringVar(&opts.configPath, "config", opts.configPath, "path to a JSON config file")
-	fs.StringVar(&opts.presetName, "preset", opts.presetName, "visual preset: none, dark, light, plain, pretty")
+	fs.StringVar(&opts.presetName, "theme", opts.presetName, "visual theme: dark, light, plain, pretty")
 	fs.StringVar(&opts.chromeName, "chrome", opts.chromeName, "chrome override: auto, none, single, rounded")
 	fs.StringVar(&opts.renderName, "render", opts.renderName, "render mode: hybrid, literal, presentation")
 	fs.StringVar(&opts.title, "title", opts.title, "frame title")
@@ -1596,7 +1596,7 @@ func programPreset(name string) (goless.Preset, error) {
 	case "pretty":
 		return goless.PrettyPreset, nil
 	default:
-		return goless.Preset{}, fmt.Errorf("unknown preset %q; expected none, dark, light, plain, or pretty", name)
+		return goless.Preset{}, fmt.Errorf("unknown theme %q; expected dark, light, plain, or pretty", name)
 	}
 }
 

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -21,14 +21,14 @@ import (
 )
 
 const (
-	testInputAlphaBeta         = "alpha\nbeta\n"
-	testInputOneTwo            = "one\ntwo\n"
-	testInputOneTwoThree       = "one\ntwo\nthree\n"
-	testInputOneTwoThreeFour   = "one\ntwo\nthree\nfour\n"
-	testInputOneToFive         = "one\ntwo\nthree\nfour\nfive\n"
-	testInputTallTenLines      = "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\n"
-	testSampleFileName         = "sample.txt"
-	testStdinFixtureFileName   = "stdin.txt"
+	testInputAlphaBeta       = "alpha\nbeta\n"
+	testInputOneTwo          = "one\ntwo\n"
+	testInputOneTwoThree     = "one\ntwo\nthree\n"
+	testInputOneTwoThreeFour = "one\ntwo\nthree\nfour\n"
+	testInputOneToFive       = "one\ntwo\nthree\nfour\nfive\n"
+	testInputTallTenLines    = "one\ntwo\nthree\nfour\nfive\nsix\nseven\neight\nnine\nten\n"
+	testSampleFileName       = "sample.txt"
+	testStdinFixtureFileName = "stdin.txt"
 )
 
 func runProgramForTest(t *testing.T, args []string, stdin string) (string, error) {
@@ -1019,13 +1019,13 @@ func TestRunRejectsUnknownRenderMode(t *testing.T) {
 	}
 }
 
-func TestRunRejectsUnknownPreset(t *testing.T) {
-	_, err := runProgramForTest(t, []string{"--preset", "bogus"}, "")
+func TestRunRejectsUnknownTheme(t *testing.T) {
+	_, err := runProgramForTest(t, []string{"--theme", "bogus"}, "")
 	if err == nil {
-		t.Fatal("run(--preset bogus) = nil error, want error")
+		t.Fatal("run(--theme bogus) = nil error, want error")
 	}
-	if got := err.Error(); !strings.Contains(got, "unknown preset") {
-		t.Fatalf("run(--preset bogus) error = %q, want unknown preset", got)
+	if got := err.Error(); !strings.Contains(got, "unknown theme") {
+		t.Fatalf("run(--theme bogus) error = %q, want unknown theme", got)
 	}
 }
 

--- a/site/content/user-manual/getting-started.md
+++ b/site/content/user-manual/getting-started.md
@@ -28,7 +28,7 @@ and writes the selected input unchanged instead of opening the full-screen UI.
 When you are viewing a regular file in the full-screen UI, `v` opens that file
 in `$EDITOR` at the current line. Use `-secure` to disable editor launch.
 
-If you want a default visual preset, `goless` also looks for a per-user JSON
+If you want a default visual theme, `goless` also looks for a per-user JSON
 config at `goless/config.json` under the directory returned by
 `os.UserConfigDir()`.
 
@@ -42,7 +42,7 @@ The initial format is:
 
 ```json
 {
-  "preset": "pretty",
+  "theme": "pretty",
   "hidden": false,
   "line-numbers": false,
   "live-links": false,

--- a/site/content/user-manual/getting-started.md
+++ b/site/content/user-manual/getting-started.md
@@ -28,6 +28,30 @@ and writes the selected input unchanged instead of opening the full-screen UI.
 When you are viewing a regular file in the full-screen UI, `v` opens that file
 in `$EDITOR` at the current line. Use `-secure` to disable editor launch.
 
+If you want a default visual preset, `goless` also looks for a per-user JSON
+config at `goless/config.json` under the directory returned by
+`os.UserConfigDir()`.
+
+Config selection precedence is:
+
+1. `-config path`
+2. `GOLESS_CONFIG`
+3. the default per-user config path
+
+The initial format is:
+
+```json
+{
+  "preset": "pretty",
+  "hidden": false,
+  "line-numbers": false,
+  "live-links": false,
+  "secure": false
+}
+```
+
+Command-line flags still win over config values for a single invocation.
+
 ## What Users Need First
 
 The first user-facing page should answer these questions quickly:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Per-user JSON config support plus a -config flag; GOLESS_CONFIG env var supported; CLI flags override config.

* **Documentation**
  * Replaced -preset with -theme (F4 cycles visual themes). Docs updated with config schema, discovery path, precedence, and -config usage.

* **Bug Fixes**
  * Stricter config validation and clearer "unknown theme" errors.

* **Tests**
  * Added comprehensive tests for config loading, precedence, parsing errors, and flag overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->