### PR TITLE
Fix --help output

### DIFF
--- a/cmd/goless/config_test.go
+++ b/cmd/goless/config_test.go
@@ -83,8 +83,7 @@ func TestParseProgramFlagsLoadsDefaultProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
 	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
 
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"sample.txt"}, &out)
+	opts, args, err := parseProgramFlags([]string{"sample.txt"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
@@ -112,8 +111,7 @@ func TestParseProgramFlagsCLIOverridesProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
 	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
 
-	var out bytes.Buffer
-	opts, _, err := parseProgramFlags([]string{"-theme", "light", "-N=false", "-hidden=false", "-live-links=false", "-secure=false"}, &out)
+	opts, _, err := parseProgramFlags([]string{"-theme", "light", "-N=false", "-hidden=false", "-live-links=false", "-secure=false"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
@@ -139,8 +137,7 @@ func TestParseProgramFlagsExplicitConfigOverridesDefaultPath(t *testing.T) {
 	writeDefaultTestProgramConfig(t, `{"theme":"dark","line-numbers":true}`)
 	explicitPath := writeTestProgramConfig(t, `{"theme":"light","hidden":true}`)
 
-	var out bytes.Buffer
-	opts, _, err := parseProgramFlags([]string{"-config", explicitPath}, &out)
+	opts, _, err := parseProgramFlags([]string{"-config", explicitPath})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
@@ -163,8 +160,7 @@ func TestParseProgramFlagsLoadsEnvProgramConfig(t *testing.T) {
 	envPath := writeTestProgramConfig(t, `{"theme":"light","hidden":true,"line-numbers":true}`)
 	t.Setenv("GOLESS_CONFIG", envPath)
 
-	var out bytes.Buffer
-	opts, _, err := parseProgramFlags([]string{"sample.txt"}, &out)
+	opts, _, err := parseProgramFlags([]string{"sample.txt"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
@@ -188,8 +184,7 @@ func TestParseProgramFlagsEnvConfigOverridesDefaultPath(t *testing.T) {
 	envPath := writeTestProgramConfig(t, `{"theme":"light","hidden":true}`)
 	t.Setenv("GOLESS_CONFIG", envPath)
 
-	var out bytes.Buffer
-	opts, _, err := parseProgramFlags([]string{"sample.txt"}, &out)
+	opts, _, err := parseProgramFlags([]string{"sample.txt"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
@@ -207,8 +202,7 @@ func TestParseProgramFlagsExplicitConfigOverridesEnvConfig(t *testing.T) {
 	explicitPath := writeTestProgramConfigAtPath(t, filepath.Join(t.TempDir(), "explicit.json"), `{"theme":"light","hidden":false,"line-numbers":true}`)
 	t.Setenv("GOLESS_CONFIG", envPath)
 
-	var out bytes.Buffer
-	opts, _, err := parseProgramFlags([]string{"-config", explicitPath}, &out)
+	opts, _, err := parseProgramFlags([]string{"-config", explicitPath})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
@@ -229,8 +223,7 @@ func TestParseProgramFlagsExplicitConfigOverridesEnvConfig(t *testing.T) {
 func TestParseProgramFlagsRejectsMissingExplicitConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
 
-	var out bytes.Buffer
-	_, _, err := parseProgramFlags([]string{"-config", filepath.Join(t.TempDir(), "missing.json")}, &out)
+	_, _, err := parseProgramFlags([]string{"-config", filepath.Join(t.TempDir(), "missing.json")})
 	if err == nil {
 		t.Fatal("parseProgramFlags(-config missing) = nil error, want error")
 	}
@@ -243,8 +236,7 @@ func TestParseProgramFlagsHelpSkipsBrokenDefaultProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
 	writeDefaultTestProgramConfig(t, `{"theme":"dark"`)
 
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"--help"}, &out)
+	opts, args, err := parseProgramFlags([]string{"--help"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(--help) failed: %v", err)
 	}
@@ -261,8 +253,7 @@ func TestParseProgramFlagsVersionSkipsBrokenEnvProgramConfig(t *testing.T) {
 	path := writeTestProgramConfig(t, `{"theme":"dark"`)
 	t.Setenv("GOLESS_CONFIG", path)
 
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"--version"}, &out)
+	opts, args, err := parseProgramFlags([]string{"--version"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(--version) failed: %v", err)
 	}
@@ -278,8 +269,7 @@ func TestParseProgramFlagsHelpSkipsBrokenExplicitProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
 	path := writeTestProgramConfig(t, `{"theme":"dark"`)
 
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"--help", "-config", path}, &out)
+	opts, args, err := parseProgramFlags([]string{"--help", "-config", path})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(--help, -config) failed: %v", err)
 	}
@@ -295,8 +285,7 @@ func TestParseProgramFlagsVersionSkipsBrokenExplicitProgramConfig(t *testing.T) 
 	setTestProgramConfigHome(t)
 	path := writeTestProgramConfig(t, `{"theme":"dark"`)
 
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"--version", "-config", path}, &out)
+	opts, args, err := parseProgramFlags([]string{"--version", "-config", path})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(--version, -config) failed: %v", err)
 	}
@@ -384,19 +373,13 @@ func TestProgramConfigPathFromArgsStopsAtDoubleDash(t *testing.T) {
 	}
 }
 
-func TestParseProgramFlagsHelpMentionsConfig(t *testing.T) {
+func TestWriteProgramUsageMentionsConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
 
 	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"--help"}, &out)
-	if err != nil {
-		t.Fatalf("parseProgramFlags(--help) failed: %v", err)
-	}
-	if !opts.showHelp {
-		t.Fatal("parseProgramFlags(--help) did not set showHelp")
-	}
-	if len(args) != 0 {
-		t.Fatalf("len(args) after --help = %d, want 0", len(args))
+	writeProgramUsage(&out)
+	if got := out.String(); !strings.Contains(got, "Config:") {
+		t.Fatalf("help output = %q, want config section", got)
 	}
 	if got := out.String(); !strings.Contains(got, "GOLESS_CONFIG") {
 		t.Fatalf("help output = %q, want config path note", got)

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -18,6 +18,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"text/tabwriter"
 	"time"
 
 	"github.com/gdamore/goless"
@@ -91,6 +92,30 @@ var (
 	errProgramSaveUnavailable = errors.New("save unavailable")
 )
 
+type programDisplayedError struct {
+	err error
+}
+
+func (e programDisplayedError) Error() string {
+	return e.err.Error()
+}
+
+func (e programDisplayedError) Unwrap() error {
+	return e.err
+}
+
+type programFlagParseError struct {
+	err error
+}
+
+func (e *programFlagParseError) Error() string {
+	return e.err.Error()
+}
+
+func (e *programFlagParseError) Unwrap() error {
+	return e.err
+}
+
 type programSaveHandler struct {
 	pager  func() *goless.Pager
 	secure bool
@@ -98,17 +123,27 @@ type programSaveHandler struct {
 
 func main() {
 	if err := run(); err != nil {
+		var displayed programDisplayedError
+		if errors.As(err, &displayed) {
+			os.Exit(1)
+		}
 		fmt.Fprintln(os.Stderr, err)
 		os.Exit(1)
 	}
 }
 
 func run() error {
-	opts, args, err := parseProgramFlags(os.Args[1:], flag.CommandLine.Output())
+	opts, args, err := parseProgramFlags(os.Args[1:])
 	if err != nil {
+		var parseErr *programFlagParseError
+		if errors.As(err, &parseErr) {
+			writeProgramFlagParseError(flag.CommandLine.Output(), os.Args[1:], parseErr.err)
+			return programDisplayedError{err: err}
+		}
 		return err
 	}
 	if opts.showHelp {
+		writeProgramUsage(os.Stdout)
 		return nil
 	}
 	if opts.version {
@@ -435,7 +470,7 @@ func run() error {
 	}
 }
 
-func parseProgramFlags(args []string, output io.Writer) (programOptions, []string, error) {
+func parseProgramFlags(args []string) (programOptions, []string, error) {
 	opts := programOptions{
 		presetName:     "pretty",
 		chromeName:     "auto",
@@ -463,12 +498,7 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 	}
 
 	fs := flag.NewFlagSet("goless", flag.ContinueOnError)
-	fs.SetOutput(output)
-	fs.Usage = func() {
-		fmt.Fprintf(fs.Output(), "usage: goless [-?|-e|-E|-F|-N|-R|-S|-i|-I|-s|-secure] [-x n] [-config path] [-theme dark|light|plain|pretty] [-chrome auto|none|single|rounded] [-hidden] [-live-links] [-render hybrid|literal|presentation] [-squeeze] [-title text] [-license] [+line|+/pattern] [-version] [path ...]\n")
-		fmt.Fprintln(fs.Output(), "config: goless loads GOLESS_CONFIG when set, otherwise goless/config.json from the per-user config directory; -config overrides both")
-	}
-
+	fs.SetOutput(io.Discard)
 	fs.BoolVar(&opts.showHelp, "?", opts.showHelp, "show help")
 	fs.BoolVar(&opts.showHelp, "help", opts.showHelp, "show help")
 	fs.BoolVar(&opts.showHelp, "h", opts.showHelp, "show help")
@@ -500,10 +530,9 @@ func parseProgramFlags(args []string, output io.Writer) (programOptions, []strin
 	fs.BoolVar(&ignoreCase, "I", false, "case-insensitive search")
 
 	if err := fs.Parse(args); err != nil {
-		return programOptions{}, nil, err
+		return programOptions{}, nil, &programFlagParseError{err: err}
 	}
 	if opts.showHelp {
-		fs.Usage()
 		return opts, nil, nil
 	}
 	if ignoreSmartCase && ignoreCase {
@@ -542,6 +571,183 @@ func programHasImmediateExitFlag(args []string) bool {
 		}
 	}
 	return false
+}
+
+type programFlagHelp struct {
+	names       []string
+	value       string
+	description string
+}
+
+func programFlagHelps() []programFlagHelp {
+	return []programFlagHelp{
+		{names: []string{"-?", "-h", "--help"}, description: "Show help and exit."},
+		{names: []string{"--license"}, description: "Print the bundled Apache license and exit."},
+		{names: []string{"--version"}, description: "Print the program version and exit."},
+		{names: []string{"-e", "--quit-at-eof"}, description: "Quit on the first forward command at end of input."},
+		{names: []string{"-E", "--QUIT-AT-EOF"}, description: "Quit when EOF is already visible on screen."},
+		{names: []string{"-F"}, description: "Quit immediately if the entire input fits on one screen."},
+		{names: []string{"-N"}, description: "Show line numbers."},
+		{names: []string{"-R"}, description: "Accepted as a less-compatibility no-op."},
+		{names: []string{"-S"}, description: "Accepted as a less-compatibility no-op."},
+		{names: []string{"--hidden"}, description: "Show tabs, line endings, carriage returns, and EOF markers."},
+		{names: []string{"--live-links"}, description: "Enable live OSC 8 hyperlinks in the standalone program."},
+		{names: []string{"--secure"}, description: "Disable standalone commands that launch external programs."},
+		{names: []string{"-s", "--squeeze"}, description: "Collapse repeated blank lines in the current view."},
+		{names: []string{"--config"}, value: "<path>", description: "Load a JSON config file; overrides GOLESS_CONFIG and the default per-user path."},
+		{names: []string{"--theme"}, value: "<dark|light|plain|pretty>", description: "Select the visual theme."},
+		{names: []string{"--chrome"}, value: "<auto|none|single|rounded>", description: "Override the pager frame style."},
+		{names: []string{"--render"}, value: "<hybrid|literal|presentation>", description: "Choose how escape sequences are rendered."},
+		{names: []string{"--title"}, value: "<text>", description: "Set the frame title."},
+		{names: []string{"-x"}, value: "<n>", description: "Set the tab width."},
+		{names: []string{"-i"}, description: "Use smart-case search."},
+		{names: []string{"-I"}, description: "Use case-insensitive search."},
+	}
+}
+
+func writeProgramUsage(w io.Writer) {
+	if w == nil {
+		return
+	}
+
+	fmt.Fprintln(w, "Usage:")
+	fmt.Fprintln(w, "  goless [options] [+line | +/pattern] [path ...]")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Options:")
+
+	tw := tabwriter.NewWriter(w, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "  Option\tDescription")
+	for _, item := range programFlagHelps() {
+		fmt.Fprintf(tw, "  %s\t%s\n", programFormatFlagNames(item.names, item.value), item.description)
+	}
+	_ = tw.Flush()
+
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Startup:")
+	fmt.Fprintln(w, "  +line       Jump to a 1-based line number before opening the viewer.")
+	fmt.Fprintln(w, "  +/pattern   Jump to the first match for pattern before opening the viewer.")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Config:")
+	fmt.Fprintln(w, "  goless loads GOLESS_CONFIG when set, otherwise goless/config.json from the")
+	fmt.Fprintln(w, "  per-user config directory; --config overrides both.")
+}
+
+func programFormatFlagNames(names []string, value string) string {
+	var formatted []string
+	for _, name := range names {
+		if value == "" {
+			formatted = append(formatted, name)
+			continue
+		}
+		formatted = append(formatted, name+" "+value)
+	}
+	return strings.Join(formatted, ", ")
+}
+
+func writeProgramFlagParseError(w io.Writer, args []string, err error) {
+	if w == nil {
+		return
+	}
+
+	fmt.Fprintln(w, programFormatFlagParseError(args, err))
+	fmt.Fprintf(w, "See %s --help for assistance.\n", programInvocationName())
+}
+
+func programFormatFlagParseError(args []string, err error) string {
+	msg := err.Error()
+	if bad, ok := strings.CutPrefix(msg, "flag provided but not defined: "); ok {
+		bad = programOriginalUnknownFlag(args, bad)
+		formatted := "unknown option " + bad
+		if suggestion := programSuggestFlag(bad); suggestion != "" {
+			formatted += "; did you mean " + suggestion + "?"
+		}
+		return formatted
+	}
+	return msg
+}
+
+func programInvocationName() string {
+	if len(os.Args) == 0 || os.Args[0] == "" {
+		return "goless"
+	}
+	return filepath.Base(os.Args[0])
+}
+
+func programOriginalUnknownFlag(args []string, normalized string) string {
+	for _, arg := range args {
+		name, _, _ := strings.Cut(arg, "=")
+		if name == normalized {
+			return name
+		}
+		if strings.HasPrefix(name, "--") && "-"+strings.TrimPrefix(name, "--") == normalized {
+			return name
+		}
+	}
+	return normalized
+}
+
+func programSuggestFlag(name string) string {
+	candidates := []string{
+		"--help",
+		"--license",
+		"--version",
+		"--quit-at-eof",
+		"--QUIT-AT-EOF",
+		"--hidden",
+		"--live-links",
+		"--secure",
+		"--squeeze",
+		"--config",
+		"--theme",
+		"--chrome",
+		"--render",
+		"--title",
+	}
+
+	best := ""
+	bestDistance := 3
+	for _, candidate := range candidates {
+		if distance := programEditDistance(name, candidate); distance < bestDistance {
+			best = candidate
+			bestDistance = distance
+		}
+	}
+	return best
+}
+
+func programEditDistance(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if len(a) == 0 {
+		return len(b)
+	}
+	if len(b) == 0 {
+		return len(a)
+	}
+
+	prev := make([]int, len(b)+1)
+	curr := make([]int, len(b)+1)
+	for j := range prev {
+		prev[j] = j
+	}
+
+	for i := 1; i <= len(a); i++ {
+		curr[0] = i
+		for j := 1; j <= len(b); j++ {
+			cost := 0
+			if a[i-1] != b[j-1] {
+				cost = 1
+			}
+			curr[j] = min(
+				prev[j]+1,
+				curr[j-1]+1,
+				prev[j-1]+cost,
+			)
+		}
+		prev, curr = curr, prev
+	}
+	return prev[len(b)]
 }
 
 func programConfigPathFromArgs(args []string) (string, bool, error) {

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -37,6 +37,81 @@ func runProgramForTest(t *testing.T, args []string, stdin string) (string, error
 	return runProgramForTestWithOptions(t, args, programRunTestOptions{stdin: stdin})
 }
 
+func runProgramForTestWithStreams(t *testing.T, args []string, stdin string) (string, string, error) {
+	t.Helper()
+
+	stdinPath := writeTempFile(t, t.TempDir(), testStdinFixtureFileName, stdin)
+	stdinFile, err := os.Open(stdinPath)
+	if err != nil {
+		t.Fatalf("Open(stdin) failed: %v", err)
+	}
+	defer stdinFile.Close()
+
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe(stdout) failed: %v", err)
+	}
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("Pipe(stderr) failed: %v", err)
+	}
+	type streamResult struct {
+		data []byte
+		err  error
+	}
+	stdoutDone := make(chan streamResult, 1)
+	stderrDone := make(chan streamResult, 1)
+	go func() {
+		data, err := io.ReadAll(stdoutReader)
+		stdoutDone <- streamResult{data: data, err: err}
+	}()
+	go func() {
+		data, err := io.ReadAll(stderrReader)
+		stderrDone <- streamResult{data: data, err: err}
+	}()
+
+	oldArgs := os.Args
+	oldStdin := os.Stdin
+	oldStdout := os.Stdout
+	oldStderr := os.Stderr
+	oldFlagOutput := flag.CommandLine.Output()
+	os.Args = append([]string{"goless"}, args...)
+	os.Stdin = stdinFile
+	os.Stdout = stdoutWriter
+	os.Stderr = stderrWriter
+	flag.CommandLine.SetOutput(stderrWriter)
+
+	runErr := run()
+
+	flag.CommandLine.SetOutput(oldFlagOutput)
+	os.Args = oldArgs
+	os.Stdin = oldStdin
+	os.Stdout = oldStdout
+	os.Stderr = oldStderr
+
+	if err := stdoutWriter.Close(); err != nil {
+		t.Fatalf("Close(stdout writer) failed: %v", err)
+	}
+	if err := stderrWriter.Close(); err != nil {
+		t.Fatalf("Close(stderr writer) failed: %v", err)
+	}
+	stdoutResult := <-stdoutDone
+	if stdoutResult.err != nil {
+		t.Fatalf("ReadAll(stdout) failed: %v", stdoutResult.err)
+	}
+	stderrResult := <-stderrDone
+	if stderrResult.err != nil {
+		t.Fatalf("ReadAll(stderr) failed: %v", stderrResult.err)
+	}
+	if err := stdoutReader.Close(); err != nil {
+		t.Fatalf("Close(stdout reader) failed: %v", err)
+	}
+	if err := stderrReader.Close(); err != nil {
+		t.Fatalf("Close(stderr reader) failed: %v", err)
+	}
+	return string(stdoutResult.data), string(stderrResult.data), runErr
+}
+
 type programRunTestOptions struct {
 	stdin          string
 	stdinTerminal  *bool
@@ -831,8 +906,7 @@ func TestHandleProgramPostInputSkipsEOFPoliciesForLicenseView(t *testing.T) {
 }
 
 func TestParseProgramFlagsCompatibilityAliases(t *testing.T) {
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"-F", "-S", "-N", "-s", "-x", "4", "-I", "sample.txt"}, &out)
+	opts, args, err := parseProgramFlags([]string{"-F", "-S", "-N", "-s", "-x", "4", "-I", "sample.txt"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
@@ -863,8 +937,7 @@ func TestParseProgramFlagsCompatibilityAliases(t *testing.T) {
 }
 
 func TestParseProgramFlagsSecure(t *testing.T) {
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"-secure", "sample.txt"}, &out)
+	opts, args, err := parseProgramFlags([]string{"-secure", "sample.txt"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(-secure) failed: %v", err)
 	}
@@ -880,24 +953,19 @@ func TestParseProgramFlagsSecure(t *testing.T) {
 }
 
 func TestParseProgramFlagsRejectsConflictingSearchCaseFlags(t *testing.T) {
-	var out bytes.Buffer
-
-	if _, _, err := parseProgramFlags([]string{"-i", "-I"}, &out); err == nil {
+	if _, _, err := parseProgramFlags([]string{"-i", "-I"}); err == nil {
 		t.Fatal("parseProgramFlags(-i, -I) = nil error, want mutual exclusion error")
 	}
 }
 
 func TestParseProgramFlagsRejectsNonPositiveTabWidth(t *testing.T) {
-	var out bytes.Buffer
-
-	if _, _, err := parseProgramFlags([]string{"-x", "0"}, &out); err == nil {
+	if _, _, err := parseProgramFlags([]string{"-x", "0"}); err == nil {
 		t.Fatal("parseProgramFlags(-x 0) = nil error, want invalid tab width error")
 	}
 }
 
 func TestParseProgramFlagsVersion(t *testing.T) {
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"-version"}, &out)
+	opts, args, err := parseProgramFlags([]string{"-version"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(-version) failed: %v", err)
 	}
@@ -920,8 +988,7 @@ func TestRunVersion(t *testing.T) {
 }
 
 func TestParseProgramFlagsHelp(t *testing.T) {
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"--help"}, &out)
+	opts, args, err := parseProgramFlags([]string{"--help"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(--help) failed: %v", err)
 	}
@@ -931,12 +998,8 @@ func TestParseProgramFlagsHelp(t *testing.T) {
 	if len(args) != 0 {
 		t.Fatalf("len(args) after --help = %d, want 0", len(args))
 	}
-	if got := out.String(); !strings.Contains(got, "usage: goless") {
-		t.Fatalf("help output = %q, want usage text", got)
-	}
 
-	out.Reset()
-	opts, args, err = parseProgramFlags([]string{"-?"}, &out)
+	opts, args, err = parseProgramFlags([]string{"-?"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(-?) failed: %v", err)
 	}
@@ -946,12 +1009,8 @@ func TestParseProgramFlagsHelp(t *testing.T) {
 	if len(args) != 0 {
 		t.Fatalf("len(args) after -? = %d, want 0", len(args))
 	}
-	if got := out.String(); !strings.Contains(got, "usage: goless") {
-		t.Fatalf("help output for -? = %q, want usage text", got)
-	}
 
-	out.Reset()
-	opts, args, err = parseProgramFlags([]string{"-h"}, &out)
+	opts, args, err = parseProgramFlags([]string{"-h"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(-h) failed: %v", err)
 	}
@@ -961,9 +1020,6 @@ func TestParseProgramFlagsHelp(t *testing.T) {
 	if len(args) != 0 {
 		t.Fatalf("len(args) after -h = %d, want 0", len(args))
 	}
-	if got := out.String(); !strings.Contains(got, "usage: goless") {
-		t.Fatalf("help output for -h = %q, want usage text", got)
-	}
 }
 
 func TestRunHelp(t *testing.T) {
@@ -971,14 +1027,67 @@ func TestRunHelp(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run(--help) failed: %v", err)
 	}
-	if !strings.Contains(output, "usage: goless") {
-		t.Fatalf("run(--help) output = %q, want usage text", output)
+	if !strings.Contains(output, "Options:") {
+		t.Fatalf("run(--help) output = %q, want options table", output)
+	}
+	if !strings.Contains(output, "Show help and exit.") {
+		t.Fatalf("run(--help) output = %q, want descriptive text", output)
+	}
+}
+
+func TestRunHelpWritesToStdout(t *testing.T) {
+	stdout, stderr, err := runProgramForTestWithStreams(t, []string{"--help"}, "")
+	if err != nil {
+		t.Fatalf("run(--help) failed: %v", err)
+	}
+	if !strings.Contains(stdout, "Options:") {
+		t.Fatalf("stdout = %q, want options table", stdout)
+	}
+	if !strings.Contains(stdout, "Show help and exit.") {
+		t.Fatalf("stdout = %q, want descriptive text", stdout)
+	}
+	if stderr != "" {
+		t.Fatalf("stderr = %q, want empty output", stderr)
+	}
+}
+
+func TestRunUnknownFlagShowsHelpHint(t *testing.T) {
+	output, err := runProgramForTest(t, []string{"--hep"}, "")
+	if err == nil {
+		t.Fatal("run(--hep) = nil error, want error")
+	}
+	if got := output; !strings.Contains(got, "unknown option --hep; did you mean --help?") {
+		t.Fatalf("run(--hep) output = %q, want suggestion", got)
+	}
+	if got := output; !strings.Contains(got, "See goless --help for assistance.") {
+		t.Fatalf("run(--hep) output = %q, want help hint", got)
+	}
+	if got := output; strings.Contains(got, "Options:") {
+		t.Fatalf("run(--hep) output = %q, do not want usage table", got)
+	}
+}
+
+func TestRunUnknownFlagWritesToStderr(t *testing.T) {
+	stdout, stderr, err := runProgramForTestWithStreams(t, []string{"--hep"}, "")
+	if err == nil {
+		t.Fatal("run(--hep) = nil error, want error")
+	}
+	if stdout != "" {
+		t.Fatalf("stdout = %q, want empty output", stdout)
+	}
+	if !strings.Contains(stderr, "unknown option --hep; did you mean --help?") {
+		t.Fatalf("stderr = %q, want suggestion", stderr)
+	}
+	if !strings.Contains(stderr, "See goless --help for assistance.") {
+		t.Fatalf("stderr = %q, want help hint", stderr)
+	}
+	if strings.Contains(stderr, "Options:") {
+		t.Fatalf("stderr = %q, do not want usage table", stderr)
 	}
 }
 
 func TestParseProgramFlagsLicense(t *testing.T) {
-	var out bytes.Buffer
-	opts, args, err := parseProgramFlags([]string{"--license"}, &out)
+	opts, args, err := parseProgramFlags([]string{"--license"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(--license) failed: %v", err)
 	}
@@ -1094,13 +1203,11 @@ func TestRunPassThroughReportsOpenError(t *testing.T) {
 }
 
 func TestParseProgramFlagsLicenseExclusive(t *testing.T) {
-	var out bytes.Buffer
-	_, _, err := parseProgramFlags([]string{"--license", "-N"}, &out)
+	_, _, err := parseProgramFlags([]string{"--license", "-N"})
 	if err == nil {
 		t.Fatal("parseProgramFlags(--license -N) = nil error, want error")
 	}
-	out.Reset()
-	if _, _, err := parseProgramFlags([]string{"--license", "file.txt"}, &out); err == nil {
+	if _, _, err := parseProgramFlags([]string{"--license", "file.txt"}); err == nil {
 		t.Fatal("parseProgramFlags(--license file.txt) = nil error, want error")
 	}
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Redesigned CLI help/usage output with clearer, labeled sections (Usage, Options) printed to stdout.
  * Intelligent flag suggestions for unknown or mistyped options to guide correct flag usage.

* **Bug Fixes**
  * Consistent exit behavior and cleaner error messages when flag parsing fails; parse errors and suggestions are written to stderr without duplicate traces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->