### PR TITLE
Add support for emitting default configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,7 @@ Program flags:
 - `-i` for smart-case search behavior
 - `-I` for case-insensitive search behavior
 - `--license` to open the bundled Apache license, or print it when stdout is not a terminal
+- `--default-config` to print the built-in JSON config to stdout
 - `-config path` to load a specific JSON config file instead of the default per-user path
 - `-x n` to set tab width
 - `-theme dark|light|plain|pretty`
@@ -356,6 +357,8 @@ When present, `goless` also loads per-user configuration from
 `goless/config.json` under the OS config directory returned by
 `os.UserConfigDir()`; on most Linux systems that means
 `$XDG_CONFIG_HOME/goless/config.json` or `~/.config/goless/config.json`.
+On macOS that is typically `~/Library/Application Support/goless/config.json`.
+On Windows that is typically `%AppData%\goless\config.json`.
 
 Config selection precedence is:
 
@@ -374,6 +377,9 @@ The initial config schema is intentionally small:
   "secure": false
 }
 ```
+
+Use `goless --default-config` to print that built-in config and redirect it into
+`goless/config.json` or another starter file.
 
 CLI flags still take precedence over config values, so
 `goless -config ./alt.json -theme dark file.txt` overrides the selected config

--- a/cmd/goless/config.go
+++ b/cmd/goless/config.go
@@ -21,6 +21,24 @@ type programConfig struct {
 	Theme       string `json:"theme"`
 }
 
+type programConfigDefaults struct {
+	Theme       string `json:"theme"`
+	Hidden      bool   `json:"hidden"`
+	LineNumbers bool   `json:"line-numbers"`
+	LiveLinks   bool   `json:"live-links"`
+	Secure      bool   `json:"secure"`
+}
+
+func defaultProgramConfigValues() programConfigDefaults {
+	return programConfigDefaults{
+		Theme:       programDefaultTheme,
+		Hidden:      false,
+		LineNumbers: false,
+		LiveLinks:   false,
+		Secure:      false,
+	}
+}
+
 func defaultProgramConfigPath() (string, error) {
 	dir, err := os.UserConfigDir()
 	if err != nil {
@@ -109,4 +127,16 @@ func applyProgramConfig(opts programOptions, cfg programConfig) programOptions {
 		opts.presetName = cfg.Theme
 	}
 	return opts
+}
+
+func writeDefaultProgramConfig(w io.Writer) error {
+	if w == nil {
+		return nil
+	}
+	data, err := json.MarshalIndent(defaultProgramConfigValues(), "", "  ")
+	if err != nil {
+		return err
+	}
+	_, err = fmt.Fprintln(w, string(data))
+	return err
 }

--- a/cmd/goless/config_test.go
+++ b/cmd/goless/config_test.go
@@ -11,6 +11,31 @@ import (
 	"testing"
 )
 
+func TestDefaultProgramConfigValues(t *testing.T) {
+	got := defaultProgramConfigValues()
+	want := programConfigDefaults{
+		Theme:       programDefaultTheme,
+		Hidden:      false,
+		LineNumbers: false,
+		LiveLinks:   false,
+		Secure:      false,
+	}
+	if got != want {
+		t.Fatalf("defaultProgramConfigValues() = %+v, want %+v", got, want)
+	}
+}
+
+func TestWriteDefaultProgramConfig(t *testing.T) {
+	var out bytes.Buffer
+	if err := writeDefaultProgramConfig(&out); err != nil {
+		t.Fatalf("writeDefaultProgramConfig(...) failed: %v", err)
+	}
+	const want = "{\n  \"theme\": \"pretty\",\n  \"hidden\": false,\n  \"line-numbers\": false,\n  \"live-links\": false,\n  \"secure\": false\n}\n"
+	if got := out.String(); got != want {
+		t.Fatalf("writeDefaultProgramConfig(...) = %q, want %q", got, want)
+	}
+}
+
 func TestLoadProgramConfigMissing(t *testing.T) {
 	cfg, err := loadProgramConfigAtPath(filepath.Join(t.TempDir(), "missing.json"), true)
 	if err != nil {
@@ -297,6 +322,25 @@ func TestParseProgramFlagsVersionSkipsBrokenExplicitProgramConfig(t *testing.T) 
 	}
 }
 
+func TestParseProgramFlagsDefaultConfigSkipsBrokenExplicitProgramConfig(t *testing.T) {
+	setTestProgramConfigHome(t)
+	path := writeTestProgramConfig(t, `{"theme":"dark"`)
+
+	opts, args, err := parseProgramFlags([]string{"--default-config", "-config", path})
+	if err == nil {
+		t.Fatal("parseProgramFlags(--default-config, -config) = nil error, want exclusivity error")
+	}
+	if !strings.Contains(err.Error(), "--default-config must be used alone") {
+		t.Fatalf("parseProgramFlags(--default-config, -config) error = %q, want exclusivity detail", err)
+	}
+	if opts != (programOptions{}) {
+		t.Fatalf("parseProgramFlags(--default-config, -config) opts = %+v, want zero options on error", opts)
+	}
+	if args != nil {
+		t.Fatalf("parseProgramFlags(--default-config, -config) args = %v, want nil", args)
+	}
+}
+
 func TestProgramHasImmediateExitFlag(t *testing.T) {
 	tests := []struct {
 		name string
@@ -307,6 +351,9 @@ func TestProgramHasImmediateExitFlag(t *testing.T) {
 		{name: "help long", args: []string{"--help"}, want: true},
 		{name: "help short", args: []string{"-h"}, want: true},
 		{name: "help question", args: []string{"-?"}, want: true},
+		{name: "default config long", args: []string{"--default-config"}, want: true},
+		{name: "default config explicit true", args: []string{"--default-config=true"}, want: true},
+		{name: "default config explicit false", args: []string{"--default-config=false"}, want: false},
 		{name: "version long", args: []string{"--version"}, want: true},
 		{name: "version short", args: []string{"-version"}, want: true},
 		{name: "help explicit true", args: []string{"--help=true"}, want: true},
@@ -383,6 +430,16 @@ func TestWriteProgramUsageMentionsConfig(t *testing.T) {
 	}
 	if got := out.String(); !strings.Contains(got, "GOLESS_CONFIG") {
 		t.Fatalf("help output = %q, want config path note", got)
+	}
+	path, err := defaultProgramConfigPath()
+	if err != nil {
+		t.Fatalf("defaultProgramConfigPath() failed: %v", err)
+	}
+	if got := out.String(); !strings.Contains(got, path) {
+		t.Fatalf("help output = %q, want resolved default config path %q", got, path)
+	}
+	if got := out.String(); !strings.Contains(got, "--default-config") {
+		t.Fatalf("help output = %q, want default config flag", got)
 	}
 }
 

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -36,6 +36,7 @@ const (
 
 const programStdinInput = "-"
 const programFileFollowInterval = 250 * time.Millisecond
+const programDefaultTheme = "pretty"
 
 type programOptions struct {
 	chromeName        string
@@ -52,6 +53,7 @@ type programOptions struct {
 	renderName        string
 	searchCaseMode    goless.SearchCaseMode
 	secure            bool
+	showDefaultConfig bool
 	showHelp          bool
 	showLicense       bool
 	squeeze           bool
@@ -149,6 +151,9 @@ func run() error {
 	if opts.version {
 		fmt.Printf("goless version %s\n", version())
 		return nil
+	}
+	if opts.showDefaultConfig {
+		return writeDefaultProgramConfig(os.Stdout)
 	}
 
 	renderMode, err := programRenderMode(opts.renderName)
@@ -472,7 +477,7 @@ func run() error {
 
 func parseProgramFlags(args []string) (programOptions, []string, error) {
 	opts := programOptions{
-		presetName:     "pretty",
+		presetName:     programDefaultTheme,
 		chromeName:     "auto",
 		renderName:     "hybrid",
 		searchCaseMode: goless.SearchSmartCase,
@@ -502,6 +507,7 @@ func parseProgramFlags(args []string) (programOptions, []string, error) {
 	fs.BoolVar(&opts.showHelp, "?", opts.showHelp, "show help")
 	fs.BoolVar(&opts.showHelp, "help", opts.showHelp, "show help")
 	fs.BoolVar(&opts.showHelp, "h", opts.showHelp, "show help")
+	fs.BoolVar(&opts.showDefaultConfig, "default-config", opts.showDefaultConfig, "print the default JSON config and exit")
 	fs.BoolVar(&opts.showLicense, "license", opts.showLicense, "show the bundled Apache license")
 	fs.BoolVar(&opts.quitAtEOF, "e", opts.quitAtEOF, "quit on the first forward command at EOF")
 	fs.BoolVar(&opts.quitAtEOFFirst, "E", opts.quitAtEOFFirst, "quit when EOF is already visible on screen")
@@ -554,6 +560,14 @@ func parseProgramFlags(args []string) (programOptions, []string, error) {
 			return programOptions{}, nil, fmt.Errorf("--license cannot be combined with files")
 		}
 	}
+	if opts.showDefaultConfig {
+		if fs.NFlag() > 1 {
+			return programOptions{}, nil, fmt.Errorf("--default-config must be used alone")
+		}
+		if len(fs.Args()) > 0 {
+			return programOptions{}, nil, fmt.Errorf("--default-config cannot be combined with files")
+		}
+	}
 	return opts, fs.Args(), nil
 }
 
@@ -565,6 +579,8 @@ func programHasImmediateExitFlag(args []string) bool {
 		name, value, hasValue := strings.Cut(arg, "=")
 		switch name {
 		case "-?", "-h", "--help":
+			return !hasValue || value == "true"
+		case "-default-config", "--default-config":
 			return !hasValue || value == "true"
 		case "-version", "--version":
 			return !hasValue || value == "true"
@@ -582,6 +598,7 @@ type programFlagHelp struct {
 func programFlagHelps() []programFlagHelp {
 	return []programFlagHelp{
 		{names: []string{"-?", "-h", "--help"}, description: "Show help and exit."},
+		{names: []string{"--default-config"}, description: "Print the default JSON config to stdout and exit."},
 		{names: []string{"--license"}, description: "Print the bundled Apache license and exit."},
 		{names: []string{"--version"}, description: "Print the program version and exit."},
 		{names: []string{"-e", "--quit-at-eof"}, description: "Quit on the first forward command at end of input."},
@@ -630,6 +647,10 @@ func writeProgramUsage(w io.Writer) {
 	fmt.Fprintln(w, "Config:")
 	fmt.Fprintln(w, "  goless loads GOLESS_CONFIG when set, otherwise goless/config.json from the")
 	fmt.Fprintln(w, "  per-user config directory; --config overrides both.")
+	if path, err := defaultProgramConfigPath(); err == nil && path != "" {
+		fmt.Fprintf(w, "  Default config path: %s\n", path)
+	}
+	fmt.Fprintln(w, "  Use goless --default-config to print a starter config file to stdout.")
 }
 
 func programFormatFlagNames(names []string, value string) string {
@@ -689,6 +710,7 @@ func programOriginalUnknownFlag(args []string, normalized string) string {
 func programSuggestFlag(name string) string {
 	candidates := []string{
 		"--help",
+		"--default-config",
 		"--license",
 		"--version",
 		"--quit-at-eof",

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -977,6 +977,29 @@ func TestParseProgramFlagsVersion(t *testing.T) {
 	}
 }
 
+func TestParseProgramFlagsDefaultConfig(t *testing.T) {
+	opts, args, err := parseProgramFlags([]string{"--default-config"})
+	if err != nil {
+		t.Fatalf("parseProgramFlags(--default-config) failed: %v", err)
+	}
+	if !opts.showDefaultConfig {
+		t.Fatal("parseProgramFlags(--default-config) did not set showDefaultConfig")
+	}
+	if len(args) != 0 {
+		t.Fatalf("len(args) after --default-config = %d, want 0", len(args))
+	}
+}
+
+func TestRunDefaultConfig(t *testing.T) {
+	output, err := runProgramForTest(t, []string{"--default-config"}, "")
+	if err != nil {
+		t.Fatalf("run(--default-config) failed: %v", err)
+	}
+	if got, want := output, "{\n  \"theme\": \"pretty\",\n  \"hidden\": false,\n  \"line-numbers\": false,\n  \"live-links\": false,\n  \"secure\": false\n}\n"; got != want {
+		t.Fatalf("run(--default-config) output = %q, want %q", got, want)
+	}
+}
+
 func TestRunVersion(t *testing.T) {
 	output, err := runProgramForTest(t, []string{"--version"}, "")
 	if err != nil {
@@ -1209,6 +1232,16 @@ func TestParseProgramFlagsLicenseExclusive(t *testing.T) {
 	}
 	if _, _, err := parseProgramFlags([]string{"--license", "file.txt"}); err == nil {
 		t.Fatal("parseProgramFlags(--license file.txt) = nil error, want error")
+	}
+}
+
+func TestParseProgramFlagsDefaultConfigExclusive(t *testing.T) {
+	_, _, err := parseProgramFlags([]string{"--default-config", "-N"})
+	if err == nil {
+		t.Fatal("parseProgramFlags(--default-config -N) = nil error, want error")
+	}
+	if _, _, err := parseProgramFlags([]string{"--default-config", "file.txt"}); err == nil {
+		t.Fatal("parseProgramFlags(--default-config file.txt) = nil error, want error")
 	}
 }
 

--- a/site/content/user-manual/getting-started.md
+++ b/site/content/user-manual/getting-started.md
@@ -33,7 +33,10 @@ The standalone save command is also disabled by `-secure`.
 
 If you want a default visual theme, `goless` also looks for a per-user JSON
 config at `goless/config.json` under the directory returned by
-`os.UserConfigDir()`.
+`os.UserConfigDir()`. On macOS that is typically
+`~/Library/Application Support/goless/config.json`. On Linux that is typically
+`$XDG_CONFIG_HOME/goless/config.json` or `~/.config/goless/config.json`. On
+Windows that is typically `%AppData%\goless\config.json`.
 
 Config selection precedence is:
 
@@ -52,6 +55,9 @@ The initial format is:
   "secure": false
 }
 ```
+
+Use `goless --default-config` to print the built-in JSON and redirect it into a
+starter config file.
 
 Command-line flags still win over config values for a single invocation.
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--default-config` CLI flag to print the built-in JSON configuration to stdout.

* **Documentation**
  * Updated documentation with OS-specific default config file paths for macOS, Linux, and Windows.
  * Added guidance for seeding configuration files using the new flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->