### PR TITLE
Various navigation improvements

### DIFF
--- a/LESS_COMPATIBILITY.md
+++ b/LESS_COMPATIBILITY.md
@@ -118,7 +118,7 @@ Implemented:
 - `Q` as an additional quit key
 - `<` goes to top of file
 - `>` goes to bottom of file
-- `h` opens and closes help
+- `F1` opens and closes help
 - `W` toggles wrap so `w` can stay less-compatible
 - `R` reloads the current file/input in place
 

--- a/README.md
+++ b/README.md
@@ -341,6 +341,8 @@ Program flags:
 - `-I` for case-insensitive search behavior
 - `--license` to open the bundled Apache license, or print it when stdout is not a terminal
 - `--default-config` to print the built-in JSON config to stdout
+- `--mouse` to capture mouse button and wheel events in the standalone program
+- `--no-mouse` to disable mouse button and wheel capture in the standalone program
 - `-config path` to load a specific JSON config file instead of the default per-user path
 - `-x n` to set tab width
 - `-theme dark|light|plain|pretty`
@@ -384,7 +386,8 @@ Use `goless --default-config` to print that built-in config and redirect it into
 
 CLI flags still take precedence over config values, so
 `goless -config ./alt.json -theme dark file.txt` overrides the selected config
-file's `"theme"` value for that invocation.
+file's `"theme"` value for that invocation, and `goless --mouse file.txt`
+temporarily enables mouse capture even when the config sets `"mouse": false`.
 
 Set `"mouse": false` or pass `--no-mouse` if you want the
 standalone program to leave terminal text selection and native scrolling alone.

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ func main() {
 		return
 	}
 	defer screen.Fini()
-	screen.EnableMouse()
+	screen.EnableMouse(tcell.MouseButtonEvents)
 
 	pager.Draw(screen)
 	_ = pager.SearchForward("world")
@@ -168,7 +168,7 @@ The normal embedding model is:
    finalized.
 4. Size with `SetSize`.
 5. Render with `Draw`.
-6. If you want wheel input, call `screen.EnableMouse()`.
+6. If you want wheel input without taking over click-drag selection, call `screen.EnableMouse(tcell.MouseButtonEvents)`.
 7. Drive interaction through `HandleKey`, `HandleMouse`, or direct method calls.
 
 ## Public API Shape
@@ -374,6 +374,7 @@ The initial config schema is intentionally small:
   "hidden": false,
   "line-numbers": false,
   "live-links": false,
+  "mouse": true,
   "secure": false
 }
 ```
@@ -384,6 +385,9 @@ Use `goless --default-config` to print that built-in config and redirect it into
 CLI flags still take precedence over config values, so
 `goless -config ./alt.json -theme dark file.txt` overrides the selected config
 file's `"theme"` value for that invocation.
+
+Set `"mouse": false` or pass `--no-mouse` if you want the
+standalone program to leave terminal text selection and native scrolling alone.
 
 The default key group is intentionally less-like. Common bindings include:
 
@@ -417,7 +421,7 @@ The default key group is intentionally less-like. Common bindings include:
 - `:set searchcase=smart|case|nocase` and `:set searchmode=sub|word|regex`
 - `F` to enable follow mode
 - `Ctrl-X` or `Ctrl-C` to stop following without quitting
-- `h` or `F1` to toggle help
+- `F1` to toggle help
 
 ## Hardening and Performance
 

--- a/README.md
+++ b/README.md
@@ -392,7 +392,9 @@ standalone program to leave terminal text selection and native scrolling alone.
 The default key group is intentionally less-like. Common bindings include:
 
 - `q` or `Esc` to quit
-- `j`/`k` or arrow keys to scroll
+- `j`/`k` for one-line scrolling
+- `Up`/`Down` for coarse vertical step scrolling
+- `Shift-Up`/`Shift-Down` for fine one-line scrolling
 - `u`/`d` or `Ctrl-U`/`Ctrl-D` for half-page up/down
 - `space` for page down and `b`/`w` for page up, plus `Ctrl-B` and `Alt-V`
 - `g`/`G` for top/bottom

--- a/cmd/goless/config.go
+++ b/cmd/goless/config.go
@@ -27,6 +27,7 @@ type programConfigDefaults struct {
 	Hidden      bool   `json:"hidden"`
 	LineNumbers bool   `json:"line-numbers"`
 	LiveLinks   bool   `json:"live-links"`
+	Mouse       bool   `json:"mouse"`
 	Secure      bool   `json:"secure"`
 }
 
@@ -36,6 +37,7 @@ func defaultProgramConfigValues() programConfigDefaults {
 		Hidden:      false,
 		LineNumbers: false,
 		LiveLinks:   false,
+		Mouse:       true,
 		Secure:      false,
 	}
 }

--- a/cmd/goless/config.go
+++ b/cmd/goless/config.go
@@ -17,6 +17,7 @@ type programConfig struct {
 	Hidden      *bool  `json:"hidden"`
 	LineNumbers *bool  `json:"line-numbers"`
 	LiveLinks   *bool  `json:"live-links"`
+	Mouse       *bool  `json:"mouse"`
 	Secure      *bool  `json:"secure"`
 	Theme       string `json:"theme"`
 }
@@ -119,6 +120,9 @@ func applyProgramConfig(opts programOptions, cfg programConfig) programOptions {
 	}
 	if cfg.LiveLinks != nil {
 		opts.liveLinks = *cfg.LiveLinks
+	}
+	if cfg.Mouse != nil {
+		opts.mouseCapture = *cfg.Mouse
 	}
 	if cfg.Secure != nil {
 		opts.secure = *cfg.Secure

--- a/cmd/goless/config_test.go
+++ b/cmd/goless/config_test.go
@@ -18,6 +18,7 @@ func TestDefaultProgramConfigValues(t *testing.T) {
 		Hidden:      false,
 		LineNumbers: false,
 		LiveLinks:   false,
+		Mouse:       true,
 		Secure:      false,
 	}
 	if got != want {
@@ -30,7 +31,7 @@ func TestWriteDefaultProgramConfig(t *testing.T) {
 	if err := writeDefaultProgramConfig(&out); err != nil {
 		t.Fatalf("writeDefaultProgramConfig(...) failed: %v", err)
 	}
-	const want = "{\n  \"theme\": \"pretty\",\n  \"hidden\": false,\n  \"line-numbers\": false,\n  \"live-links\": false,\n  \"secure\": false\n}\n"
+	const want = "{\n  \"theme\": \"pretty\",\n  \"hidden\": false,\n  \"line-numbers\": false,\n  \"live-links\": false,\n  \"mouse\": true,\n  \"secure\": false\n}\n"
 	if got := out.String(); got != want {
 		t.Fatalf("writeDefaultProgramConfig(...) = %q, want %q", got, want)
 	}
@@ -160,6 +161,16 @@ func TestParseProgramFlagsCLIOverridesProgramConfig(t *testing.T) {
 	}
 	if opts.secure {
 		t.Fatal("secure = true, want CLI override false")
+	}
+}
+
+func TestParseProgramFlagsNoMouse(t *testing.T) {
+	opts, _, err := parseProgramFlags([]string{"--no-mouse"})
+	if err != nil {
+		t.Fatalf("parseProgramFlags(--no-mouse) failed: %v", err)
+	}
+	if opts.mouseCapture {
+		t.Fatal("mouseCapture = true, want false")
 	}
 }
 
@@ -446,6 +457,9 @@ func TestWriteProgramUsageMentionsConfig(t *testing.T) {
 	}
 	if got := out.String(); !strings.Contains(got, "--default-config") {
 		t.Fatalf("help output = %q, want default config flag", got)
+	}
+	if got := out.String(); !strings.Contains(got, "--mouse") {
+		t.Fatalf("help output = %q, want mouse option", got)
 	}
 	if got := out.String(); !strings.Contains(got, "--no-mouse") {
 		t.Fatalf("help output = %q, want no-mouse option", got)

--- a/cmd/goless/config_test.go
+++ b/cmd/goless/config_test.go
@@ -106,7 +106,7 @@ func TestLoadProgramConfigRejectsTrailingContent(t *testing.T) {
 
 func TestParseProgramFlagsLoadsDefaultProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
-	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
+	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":true,"line-numbers":true,"live-links":true,"mouse":false,"secure":true}`)
 
 	opts, args, err := parseProgramFlags([]string{"sample.txt"})
 	if err != nil {
@@ -124,6 +124,9 @@ func TestParseProgramFlagsLoadsDefaultProgramConfig(t *testing.T) {
 	if !opts.liveLinks {
 		t.Fatal("liveLinks = false, want true from config")
 	}
+	if opts.mouseCapture {
+		t.Fatal("mouseCapture = true, want false from config")
+	}
 	if !opts.secure {
 		t.Fatal("secure = false, want true from config")
 	}
@@ -134,9 +137,9 @@ func TestParseProgramFlagsLoadsDefaultProgramConfig(t *testing.T) {
 
 func TestParseProgramFlagsCLIOverridesProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
-	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":true,"line-numbers":true,"live-links":true,"secure":true}`)
+	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":true,"line-numbers":true,"live-links":true,"mouse":false,"secure":true}`)
 
-	opts, _, err := parseProgramFlags([]string{"-theme", "light", "-N=false", "-hidden=false", "-live-links=false", "-secure=false"})
+	opts, _, err := parseProgramFlags([]string{"-theme", "light", "-N=false", "-hidden=false", "-live-links=false", "-mouse=true", "-secure=false"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
@@ -151,6 +154,9 @@ func TestParseProgramFlagsCLIOverridesProgramConfig(t *testing.T) {
 	}
 	if opts.liveLinks {
 		t.Fatal("liveLinks = true, want CLI override false")
+	}
+	if !opts.mouseCapture {
+		t.Fatal("mouseCapture = false, want CLI override true")
 	}
 	if opts.secure {
 		t.Fatal("secure = true, want CLI override false")
@@ -440,6 +446,9 @@ func TestWriteProgramUsageMentionsConfig(t *testing.T) {
 	}
 	if got := out.String(); !strings.Contains(got, "--default-config") {
 		t.Fatalf("help output = %q, want default config flag", got)
+	}
+	if got := out.String(); !strings.Contains(got, "--no-mouse") {
+		t.Fatalf("help output = %q, want no-mouse option", got)
 	}
 }
 

--- a/cmd/goless/help.txt
+++ b/cmd/goless/help.txt
@@ -8,8 +8,10 @@
   F4                  cycle themes
 
 [1;4mNavigation[0m
-  ↓ e j Enter ^E ^N   move one line forward
-  ↑ k y ^Y ^K ^P      move one line backward
+  ↓                   move forward by a screen step
+  ↑                   move backward by a screen step
+  Shift+↓ e j Enter ^E ^N  move one line forward
+  Shift+↑ k y ^Y ^K ^P     move one line backward
   f Space PgDn ^F ^V  forward one page
   PgUp ^B b w         backward one page
   d ^D J              forward half page

--- a/cmd/goless/help.txt
+++ b/cmd/goless/help.txt
@@ -1,6 +1,6 @@
 [1;4mGeneral[0m
-  h F1                help
- q Q Esc             quit
+  F1                  help
+  q Q Esc             quit
   r ^L                repaint
   R                   reload current file/input
   s                   save to a file
@@ -12,13 +12,16 @@
   ↑ k y ^Y ^K ^P      move one line backward
   f Space PgDn ^F ^V  forward one page
   PgUp ^B b w         backward one page
-  d ^D                forward half page
-  u ^U                backward half page
+  d ^D J              forward half page
+  u ^U K              backward half page
   Home 0              jump to line start
-  End $               jump to line end
+  End $               jump to far right
   g <                 jump to top
   G >                 jump to bottom
-  ← → l               scroll horizontally faster
+  ← h                 scroll horizontally left
+  → l                 scroll horizontally right
+  H                   scroll left half screen
+  L                   scroll right half screen
   Shift+← Shift+→     scroll horizontally by 1
   W                   toggle wrap
   F                   follow the end of the document

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -46,6 +46,7 @@ type programOptions struct {
 	ignoredRawControl bool
 	lineNumbers       bool
 	liveLinks         bool
+	mouseCapture      bool
 	presetName        string
 	quitAtEOF         bool
 	quitAtEOFFirst    bool
@@ -196,7 +197,7 @@ func run() error {
 		return err
 	}
 	defer screen.Fini()
-	screen.EnableMouse()
+	programConfigureMouse(screen, opts.mouseCapture)
 
 	width, height := screen.Size()
 	if width <= 0 || height <= 0 {
@@ -267,7 +268,7 @@ func run() error {
 					}
 				},
 				func() error {
-					return editProgramCurrentFile(screen, pager, session, opts.secure, reloadDisplayed)
+					return editProgramCurrentFile(screen, pager, session, opts.secure, opts.mouseCapture, reloadDisplayed)
 				},
 				func(cmd goless.Command) (string, error) {
 					return saveHandler.save(cmd)
@@ -481,6 +482,7 @@ func parseProgramFlags(args []string) (programOptions, []string, error) {
 		chromeName:     "auto",
 		renderName:     "hybrid",
 		searchCaseMode: goless.SearchSmartCase,
+		mouseCapture:   true,
 		tabWidth:       8,
 	}
 	if !programHasImmediateExitFlag(args) {
@@ -517,6 +519,7 @@ func parseProgramFlags(args []string) (programOptions, []string, error) {
 	fs.BoolVar(&opts.ignoredChopLines, "S", opts.ignoredChopLines, "accepted as a less compatibility no-op")
 	fs.BoolVar(&opts.hidden, "hidden", opts.hidden, "show tabs, line endings, carriage returns, and EOF markers")
 	fs.BoolVar(&opts.liveLinks, "live-links", opts.liveLinks, "enable live OSC 8 hyperlinks in the program")
+	fs.BoolVar(&opts.mouseCapture, "mouse", opts.mouseCapture, "capture mouse button and wheel events in the program")
 	fs.BoolVar(&opts.quitAtEOF, "quit-at-eof", opts.quitAtEOF, "long form of -e")
 	fs.BoolVar(&opts.quitAtEOFFirst, "QUIT-AT-EOF", opts.quitAtEOFFirst, "long form of -E")
 	fs.BoolVar(&opts.secure, "secure", opts.secure, "disable standalone commands that launch external programs")
@@ -532,11 +535,16 @@ func parseProgramFlags(args []string) (programOptions, []string, error) {
 
 	var ignoreSmartCase bool
 	var ignoreCase bool
+	var noMouse bool
 	fs.BoolVar(&ignoreSmartCase, "i", false, "smart-case search")
 	fs.BoolVar(&ignoreCase, "I", false, "case-insensitive search")
+	fs.BoolVar(&noMouse, "no-mouse", false, "disable mouse capture in the program")
 
 	if err := fs.Parse(args); err != nil {
 		return programOptions{}, nil, &programFlagParseError{err: err}
+	}
+	if noMouse {
+		opts.mouseCapture = false
 	}
 	if opts.showHelp {
 		return opts, nil, nil
@@ -609,6 +617,7 @@ func programFlagHelps() []programFlagHelp {
 		{names: []string{"-S"}, description: "Accepted as a less-compatibility no-op."},
 		{names: []string{"--hidden"}, description: "Show tabs, line endings, carriage returns, and EOF markers."},
 		{names: []string{"--live-links"}, description: "Enable live OSC 8 hyperlinks in the standalone program."},
+		{names: []string{"--no-mouse"}, description: "Disable mouse button and wheel capture in the standalone program."},
 		{names: []string{"--secure"}, description: "Disable standalone commands that launch external programs."},
 		{names: []string{"-s", "--squeeze"}, description: "Collapse repeated blank lines in the current view."},
 		{names: []string{"--config"}, value: "<path>", description: "Load a JSON config file; overrides GOLESS_CONFIG and the default per-user path."},
@@ -717,6 +726,8 @@ func programSuggestFlag(name string) string {
 		"--QUIT-AT-EOF",
 		"--hidden",
 		"--live-links",
+		"--mouse",
+		"--no-mouse",
 		"--secure",
 		"--squeeze",
 		"--config",
@@ -1593,7 +1604,7 @@ func runProgramCommand(pager *goless.Pager, command string) bool {
 	return true
 }
 
-func editProgramCurrentFile(screen tcell.Screen, pager *goless.Pager, session *programSession, secure bool, reload func() error) error {
+func editProgramCurrentFile(screen tcell.Screen, pager *goless.Pager, session *programSession, secure bool, mouseCapture bool, reload func() error) error {
 	if secure {
 		return fmt.Errorf("editor disabled in secure mode")
 	}
@@ -1610,7 +1621,7 @@ func editProgramCurrentFile(screen tcell.Screen, pager *goless.Pager, session *p
 			line = row
 		}
 	}
-	if err := suspendProgramScreen(screen, pager, func() error {
+	if err := suspendProgramScreen(screen, pager, mouseCapture, func() error {
 		return programEditorLauncher(line, path)
 	}); err != nil {
 		return err
@@ -1746,7 +1757,7 @@ func shouldKeepProgramSavePrompt(err error) bool {
 		!errors.Is(err, errProgramSaveOverwrite)
 }
 
-func suspendProgramScreen(screen tcell.Screen, pager *goless.Pager, action func() error) error {
+func suspendProgramScreen(screen tcell.Screen, pager *goless.Pager, mouseCapture bool, action func() error) error {
 	if action == nil {
 		return nil
 	}
@@ -1757,7 +1768,7 @@ func suspendProgramScreen(screen tcell.Screen, pager *goless.Pager, action func(
 	actionErr := action()
 	initErr := screen.Init()
 	if initErr == nil {
-		screen.EnableMouse()
+		programConfigureMouse(screen, mouseCapture)
 		if pager != nil {
 			width, height := screen.Size()
 			pager.SetSize(width, height)
@@ -1771,6 +1782,17 @@ func suspendProgramScreen(screen tcell.Screen, pager *goless.Pager, action func(
 		return actionErr
 	}
 	return initErr
+}
+
+func programConfigureMouse(screen tcell.Screen, capture bool) {
+	if screen == nil {
+		return
+	}
+	if capture {
+		screen.EnableMouse(tcell.MouseButtonEvents)
+		return
+	}
+	screen.DisableMouse()
 }
 
 func launchProgramEditor(line int, path string) error {

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -617,6 +617,7 @@ func programFlagHelps() []programFlagHelp {
 		{names: []string{"-S"}, description: "Accepted as a less-compatibility no-op."},
 		{names: []string{"--hidden"}, description: "Show tabs, line endings, carriage returns, and EOF markers."},
 		{names: []string{"--live-links"}, description: "Enable live OSC 8 hyperlinks in the standalone program."},
+		{names: []string{"--mouse"}, description: "Capture mouse button and wheel events in the standalone program."},
 		{names: []string{"--no-mouse"}, description: "Disable mouse button and wheel capture in the standalone program."},
 		{names: []string{"--secure"}, description: "Disable standalone commands that launch external programs."},
 		{names: []string{"-s", "--squeeze"}, description: "Collapse repeated blank lines in the current view."},

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -995,7 +995,7 @@ func TestRunDefaultConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("run(--default-config) failed: %v", err)
 	}
-	if got, want := output, "{\n  \"theme\": \"pretty\",\n  \"hidden\": false,\n  \"line-numbers\": false,\n  \"live-links\": false,\n  \"secure\": false\n}\n"; got != want {
+	if got, want := output, "{\n  \"theme\": \"pretty\",\n  \"hidden\": false,\n  \"line-numbers\": false,\n  \"live-links\": false,\n  \"mouse\": true,\n  \"secure\": false\n}\n"; got != want {
 		t.Fatalf("run(--default-config) output = %q, want %q", got, want)
 	}
 }
@@ -2402,56 +2402,60 @@ func TestApplyStartupCommand(t *testing.T) {
 }
 
 func TestEditProgramCurrentFileUsesCurrentLineAndReloads(t *testing.T) {
-	previous := programEditorLauncher
-	t.Cleanup(func() {
-		programEditorLauncher = previous
-	})
+	for _, mouseCapture := range []bool{true, false} {
+		t.Run(fmt.Sprintf("mouseCapture=%v", mouseCapture), func(t *testing.T) {
+			previous := programEditorLauncher
+			t.Cleanup(func() {
+				programEditorLauncher = previous
+			})
 
-	var (
-		gotLine int
-		gotPath string
-	)
-	programEditorLauncher = func(line int, path string) error {
-		gotLine = line
-		gotPath = path
-		return nil
-	}
+			var (
+				gotLine int
+				gotPath string
+			)
+			programEditorLauncher = func(line int, path string) error {
+				gotLine = line
+				gotPath = path
+				return nil
+			}
 
-	term := vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 24})
-	screen, err := tcell.NewTerminfoScreenFromTty(term)
-	if err != nil {
-		t.Fatalf("NewTerminfoScreenFromTty failed: %v", err)
-	}
-	if err := screen.Init(); err != nil {
-		t.Fatalf("screen.Init failed: %v", err)
-	}
-	defer screen.Fini()
+			term := vt.NewMockTerm(vt.MockOptSize{X: 80, Y: 24})
+			screen, err := tcell.NewTerminfoScreenFromTty(term)
+			if err != nil {
+				t.Fatalf("NewTerminfoScreenFromTty failed: %v", err)
+			}
+			if err := screen.Init(); err != nil {
+				t.Fatalf("screen.Init failed: %v", err)
+			}
+			defer screen.Fini()
 
-	pager := goless.New(goless.Config{TabWidth: 4, WrapMode: goless.NoWrap, ShowStatus: true})
-	pager.SetSize(20, 3)
-	if err := pager.AppendString("one\ntwo\nthree\nfour\n"); err != nil {
-		t.Fatalf("AppendString failed: %v", err)
-	}
-	pager.Flush()
-	pager.JumpToLine(3)
+			pager := goless.New(goless.Config{TabWidth: 4, WrapMode: goless.NoWrap, ShowStatus: true})
+			pager.SetSize(20, 3)
+			if err := pager.AppendString("one\ntwo\nthree\nfour\n"); err != nil {
+				t.Fatalf("AppendString failed: %v", err)
+			}
+			pager.Flush()
+			pager.JumpToLine(3)
 
-	path := filepath.Join(t.TempDir(), "sample.txt")
-	session := newProgramSession([]string{path}, programStartup{})
-	reloads := 0
-	if err := editProgramCurrentFile(screen, pager, session, false, true, func() error {
-		reloads++
-		return nil
-	}); err != nil {
-		t.Fatalf("editProgramCurrentFile(...) failed: %v", err)
-	}
-	if got, want := gotLine, 3; got != want {
-		t.Fatalf("editor line = %d, want %d", got, want)
-	}
-	if got, want := gotPath, path; got != want {
-		t.Fatalf("editor path = %q, want %q", got, want)
-	}
-	if got, want := reloads, 1; got != want {
-		t.Fatalf("reload count = %d, want %d", got, want)
+			path := filepath.Join(t.TempDir(), "sample.txt")
+			session := newProgramSession([]string{path}, programStartup{})
+			reloads := 0
+			if err := editProgramCurrentFile(screen, pager, session, false, mouseCapture, func() error {
+				reloads++
+				return nil
+			}); err != nil {
+				t.Fatalf("editProgramCurrentFile(...) failed: %v", err)
+			}
+			if got, want := gotLine, 3; got != want {
+				t.Fatalf("editor line = %d, want %d", got, want)
+			}
+			if got, want := gotPath, path; got != want {
+				t.Fatalf("editor path = %q, want %q", got, want)
+			}
+			if got, want := reloads, 1; got != want {
+				t.Fatalf("reload count = %d, want %d", got, want)
+			}
+		})
 	}
 }
 

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -2438,7 +2438,7 @@ func TestEditProgramCurrentFileUsesCurrentLineAndReloads(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "sample.txt")
 	session := newProgramSession([]string{path}, programStartup{})
 	reloads := 0
-	if err := editProgramCurrentFile(screen, pager, session, false, func() error {
+	if err := editProgramCurrentFile(screen, pager, session, false, true, func() error {
 		reloads++
 		return nil
 	}); err != nil {
@@ -2457,7 +2457,7 @@ func TestEditProgramCurrentFileUsesCurrentLineAndReloads(t *testing.T) {
 
 func TestEditProgramCurrentFileSecureMode(t *testing.T) {
 	session := newProgramSession([]string{"sample.txt"}, programStartup{})
-	err := editProgramCurrentFile(nil, nil, session, true, nil)
+	err := editProgramCurrentFile(nil, nil, session, true, true, nil)
 	if err == nil {
 		t.Fatal("editProgramCurrentFile(..., secure=true, ...) = nil error, want error")
 	}
@@ -2475,7 +2475,7 @@ func TestEditProgramCurrentFileRejectsCurrentInputWithoutFile(t *testing.T) {
 		{name: "stdin session", session: newProgramSession([]string{"-"}, programStartup{})},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
-			err := editProgramCurrentFile(nil, nil, tt.session, false, nil)
+			err := editProgramCurrentFile(nil, nil, tt.session, false, true, nil)
 			if err == nil {
 				t.Fatal("editProgramCurrentFile(...) = nil error, want error")
 			}

--- a/example_test.go
+++ b/example_test.go
@@ -36,7 +36,7 @@ func ExampleNew() {
 		return
 	}
 	defer screen.Fini()
-	screen.EnableMouse()
+	screen.EnableMouse(tcell.MouseButtonEvents)
 
 	pager.Draw(screen)
 	_ = pager.HandleKeyResult(tcell.NewEventKey(tcell.KeyRune, "x", tcell.ModNone))

--- a/internal/defaults/help.txt
+++ b/internal/defaults/help.txt
@@ -1,5 +1,5 @@
 [1;4mGeneral[0m
-  h F1                help
+  F1                  help
   q Q Esc             quit
   r ^L                repaint
 
@@ -8,13 +8,16 @@
   ↑ k y ^Y ^K ^P      move one line backward
   f Space PgDn ^F ^V  forward one page
   PgUp ^B b w         backward one page
-  d ^D                forward half page
-  u ^U                backward half page
+  d ^D J              forward half page
+  u ^U K              backward half page
   Home 0              jump to line start
-  End $               jump to line end
+  End $               jump to far right
   g <                 jump to top
   G >                 jump to bottom
-  ← → l               scroll horizontally faster
+  ← h                 scroll horizontally left
+  → l                 scroll horizontally right
+  H                   scroll left half screen
+  L                   scroll right half screen
   Shift+← Shift+→     scroll horizontally by 1
   W                   toggle wrap
   F                   follow the end of the document

--- a/internal/defaults/help.txt
+++ b/internal/defaults/help.txt
@@ -4,8 +4,10 @@
   r ^L                repaint
 
 [1;4mNavigation[0m
-  ↓ e j Enter ^E ^N   move one line forward
-  ↑ k y ^Y ^K ^P      move one line backward
+  ↓                   move forward by a screen step
+  ↑                   move backward by a screen step
+  Shift+↓ e j Enter ^E ^N  move one line forward
+  Shift+↑ k y ^Y ^K ^P     move one line backward
   f Space PgDn ^F ^V  forward one page
   PgUp ^B b w         backward one page
   d ^D J              forward half page

--- a/internal/view/input.go
+++ b/internal/view/input.go
@@ -80,6 +80,8 @@ const (
 	actionQuit
 	actionScrollUp
 	actionScrollDown
+	actionScrollUpStep
+	actionScrollDownStep
 	actionScrollLeft
 	actionScrollRight
 	actionScrollLeftFine

--- a/internal/view/input.go
+++ b/internal/view/input.go
@@ -84,6 +84,8 @@ const (
 	actionScrollRight
 	actionScrollLeftFine
 	actionScrollRightFine
+	actionHalfScreenLeft
+	actionHalfScreenRight
 	actionHalfPageUp
 	actionHalfPageDown
 	actionPageUp

--- a/internal/view/input.go
+++ b/internal/view/input.go
@@ -110,6 +110,75 @@ const (
 	actionCycleSearchMode
 )
 
+func actionToKeyAction(a action) KeyAction {
+	switch a {
+	case actionQuit:
+		return KeyActionQuit
+	case actionScrollUp:
+		return KeyActionScrollUp
+	case actionScrollDown:
+		return KeyActionScrollDown
+	case actionScrollUpStep:
+		return KeyActionScrollUpStep
+	case actionScrollDownStep:
+		return KeyActionScrollDownStep
+	case actionScrollLeft:
+		return KeyActionScrollLeft
+	case actionScrollRight:
+		return KeyActionScrollRight
+	case actionScrollLeftFine:
+		return KeyActionScrollLeftFine
+	case actionScrollRightFine:
+		return KeyActionScrollRightFine
+	case actionHalfScreenLeft:
+		return KeyActionHalfScreenLeft
+	case actionHalfScreenRight:
+		return KeyActionHalfScreenRight
+	case actionHalfPageUp:
+		return KeyActionHalfPageUp
+	case actionHalfPageDown:
+		return KeyActionHalfPageDown
+	case actionPageUp:
+		return KeyActionPageUp
+	case actionPageDown:
+		return KeyActionPageDown
+	case actionGoLineStart:
+		return KeyActionGoLineStart
+	case actionGoLineEnd:
+		return KeyActionGoLineEnd
+	case actionGoTop:
+		return KeyActionGoTop
+	case actionGoBottom:
+		return KeyActionGoBottom
+	case actionToggleWrap:
+		return KeyActionToggleWrap
+	case actionPromptSearchForward:
+		return KeyActionPromptSearchForward
+	case actionPromptSearchBackward:
+		return KeyActionPromptSearchBackward
+	case actionPromptCommand:
+		return KeyActionPromptCommand
+	case actionSearchNext:
+		return KeyActionSearchNext
+	case actionSearchPrev:
+		return KeyActionSearchPrev
+	case actionRefresh:
+		return KeyActionRefresh
+	case actionToggleHelp:
+		return KeyActionToggleHelp
+	case actionFollow:
+		return KeyActionFollow
+	case actionStopFollow:
+		return KeyActionStopFollow
+	case actionCycleSearchCase:
+		return KeyActionCycleSearchCase
+	case actionCycleSearchMode:
+		return KeyActionCycleSearchMode
+	default:
+		return KeyActionNone
+	}
+}
+
 // MouseResult summarizes how the viewer handled a mouse event.
 type MouseResult struct {
 	Handled bool

--- a/internal/view/keymap.go
+++ b/internal/view/keymap.go
@@ -40,6 +40,8 @@ const (
 	KeyActionQuit                 = actionQuit
 	KeyActionScrollUp             = actionScrollUp
 	KeyActionScrollDown           = actionScrollDown
+	KeyActionScrollUpStep         = actionScrollUpStep
+	KeyActionScrollDownStep       = actionScrollDownStep
 	KeyActionScrollLeft           = actionScrollLeft
 	KeyActionScrollRight          = actionScrollRight
 	KeyActionScrollLeftFine       = actionScrollLeftFine
@@ -115,8 +117,10 @@ func lessKeyMap() keyMap {
 			{key: tcell.KeyCtrlC, action: actionQuit},
 			{key: tcell.KeyCtrlL, action: actionRefresh},
 			{key: tcell.KeyEnter, action: actionScrollDown},
-			{key: tcell.KeyUp, action: actionScrollUp},
-			{key: tcell.KeyDown, action: actionScrollDown},
+			{key: tcell.KeyUp, action: actionScrollUpStep},
+			{key: tcell.KeyDown, action: actionScrollDownStep},
+			{key: tcell.KeyUp, mod: tcell.ModShift, action: actionScrollUp},
+			{key: tcell.KeyDown, mod: tcell.ModShift, action: actionScrollDown},
 			{key: tcell.KeyRune, rune: "y", mod: tcell.ModCtrl, action: actionScrollUp},
 			{key: tcell.KeyRune, rune: "k", mod: tcell.ModCtrl, action: actionScrollUp},
 			{key: tcell.KeyRune, rune: "p", mod: tcell.ModCtrl, action: actionScrollUp},
@@ -179,8 +183,10 @@ func lessKeyMap() keyMap {
 			{key: tcell.KeyCtrlC, action: actionQuit},
 			{key: tcell.KeyCtrlL, action: actionRefresh},
 			{key: tcell.KeyEnter, action: actionScrollDown},
-			{key: tcell.KeyUp, action: actionScrollUp},
-			{key: tcell.KeyDown, action: actionScrollDown},
+			{key: tcell.KeyUp, action: actionScrollUpStep},
+			{key: tcell.KeyDown, action: actionScrollDownStep},
+			{key: tcell.KeyUp, mod: tcell.ModShift, action: actionScrollUp},
+			{key: tcell.KeyDown, mod: tcell.ModShift, action: actionScrollDown},
 			{key: tcell.KeyRune, rune: "y", mod: tcell.ModCtrl, action: actionScrollUp},
 			{key: tcell.KeyRune, rune: "k", mod: tcell.ModCtrl, action: actionScrollUp},
 			{key: tcell.KeyRune, rune: "p", mod: tcell.ModCtrl, action: actionScrollUp},

--- a/internal/view/keymap.go
+++ b/internal/view/keymap.go
@@ -44,6 +44,8 @@ const (
 	KeyActionScrollRight          = actionScrollRight
 	KeyActionScrollLeftFine       = actionScrollLeftFine
 	KeyActionScrollRightFine      = actionScrollRightFine
+	KeyActionHalfScreenLeft       = actionHalfScreenLeft
+	KeyActionHalfScreenRight      = actionHalfScreenRight
 	KeyActionHalfPageUp           = actionHalfPageUp
 	KeyActionHalfPageDown         = actionHalfPageDown
 	KeyActionPageUp               = actionPageUp
@@ -142,8 +144,12 @@ func lessKeyMap() keyMap {
 			{key: tcell.KeyRune, rune: "e", action: actionScrollDown},
 			{key: tcell.KeyRune, rune: "j", action: actionScrollDown},
 			{key: tcell.KeyRune, rune: "k", action: actionScrollUp},
-			{key: tcell.KeyRune, rune: "h", action: actionToggleHelp},
+			{key: tcell.KeyRune, rune: "h", action: actionScrollLeft},
 			{key: tcell.KeyRune, rune: "l", action: actionScrollRight},
+			{key: tcell.KeyRune, rune: "H", mod: tcell.ModShift, action: actionHalfScreenLeft},
+			{key: tcell.KeyRune, rune: "L", mod: tcell.ModShift, action: actionHalfScreenRight},
+			{key: tcell.KeyRune, rune: "K", mod: tcell.ModShift, action: actionHalfPageUp},
+			{key: tcell.KeyRune, rune: "J", mod: tcell.ModShift, action: actionHalfPageDown},
 			{key: tcell.KeyRune, rune: "u", mod: tcell.ModCtrl, action: actionHalfPageUp},
 			{key: tcell.KeyRune, rune: "d", mod: tcell.ModCtrl, action: actionHalfPageDown},
 			{key: tcell.KeyRune, rune: "u", action: actionHalfPageUp},
@@ -195,8 +201,12 @@ func lessKeyMap() keyMap {
 			{key: tcell.KeyRune, rune: "e", action: actionScrollDown},
 			{key: tcell.KeyRune, rune: "j", action: actionScrollDown},
 			{key: tcell.KeyRune, rune: "k", action: actionScrollUp},
-			{key: tcell.KeyRune, rune: "h", action: actionToggleHelp},
+			{key: tcell.KeyRune, rune: "h", action: actionScrollLeft},
 			{key: tcell.KeyRune, rune: "l", action: actionScrollRight},
+			{key: tcell.KeyRune, rune: "H", mod: tcell.ModShift, action: actionHalfScreenLeft},
+			{key: tcell.KeyRune, rune: "L", mod: tcell.ModShift, action: actionHalfScreenRight},
+			{key: tcell.KeyRune, rune: "K", mod: tcell.ModShift, action: actionHalfPageUp},
+			{key: tcell.KeyRune, rune: "J", mod: tcell.ModShift, action: actionHalfPageDown},
 			{key: tcell.KeyRune, rune: "u", mod: tcell.ModCtrl, action: actionHalfPageUp},
 			{key: tcell.KeyRune, rune: "d", mod: tcell.ModCtrl, action: actionHalfPageDown},
 			{key: tcell.KeyRune, rune: "u", action: actionHalfPageUp},

--- a/internal/view/text.go
+++ b/internal/view/text.go
@@ -131,7 +131,7 @@ func (t Text) withDefaults() Text {
 func defaultText() Text {
 	return Text{
 		HelpTitle: "Help",
-		HelpClose: "Esc/q/H/F1 close",
+		HelpClose: "Esc/q/F1 close",
 		HelpBody:  defaults.HelpBody,
 		StatusSearchInfo: func(query string, current, total int) string {
 			return fmt.Sprintf("/%s %d/%d", query, current, total)

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -609,7 +609,7 @@ func (v *Viewer) HandleKeyResult(ev *tcell.EventKey) KeyResult {
 		return KeyResult{}
 	}
 
-	return KeyResult{Handled: true, Action: KeyAction(a), Context: KeyContextNormal}
+	return KeyResult{Handled: true, Action: actionToKeyAction(a), Context: KeyContextNormal}
 }
 
 // HandleMouseResult applies a mouse event and reports whether it was handled.
@@ -635,7 +635,7 @@ func (v *Viewer) HandleMouseResult(ev *tcell.EventMouse) MouseResult {
 		return MouseResult{Context: KeyContextNormal}
 	}
 
-	return MouseResult{Handled: true, Action: KeyAction(a), Context: KeyContextNormal}
+	return MouseResult{Handled: true, Action: actionToKeyAction(a), Context: KeyContextNormal}
 }
 
 func (v *Viewer) consumeTransientMessage() {
@@ -718,6 +718,10 @@ func (v *Viewer) horizontalScrollStep() int {
 
 func (v *Viewer) verticalScrollStep() int {
 	return max(1, min(8, v.scrollBodyHeight()/8))
+}
+
+func (v *Viewer) helpVerticalScrollStep() int {
+	return max(1, min(8, v.helpPageStep()/8))
 }
 
 func (v *Viewer) halfHorizontalScrollStep() int {
@@ -2081,9 +2085,9 @@ func (v *Viewer) handleHelpKey(ev *tcell.EventKey) KeyResult {
 	case actionScrollDown:
 		v.helpOffset++
 	case actionScrollUpStep:
-		v.helpOffset -= v.verticalScrollStep()
+		v.helpOffset -= v.helpVerticalScrollStep()
 	case actionScrollDownStep:
-		v.helpOffset += v.verticalScrollStep()
+		v.helpOffset += v.helpVerticalScrollStep()
 	case actionScrollLeft:
 		v.helpColOffset -= v.horizontalScrollStep()
 	case actionScrollRight:
@@ -2116,7 +2120,7 @@ func (v *Viewer) handleHelpKey(ev *tcell.EventKey) KeyResult {
 		return KeyResult{Context: KeyContextHelp}
 	}
 	v.clampHelpOffset()
-	return KeyResult{Handled: true, Action: KeyAction(a), Context: KeyContextHelp}
+	return KeyResult{Handled: true, Action: actionToKeyAction(a), Context: KeyContextHelp}
 }
 
 func (v *Viewer) handleHelpMouse(ev *tcell.EventMouse) MouseResult {
@@ -2134,7 +2138,7 @@ func (v *Viewer) handleHelpMouse(ev *tcell.EventMouse) MouseResult {
 		return MouseResult{Context: KeyContextHelp}
 	}
 	v.clampHelpOffset()
-	return MouseResult{Handled: true, Action: KeyAction(a), Context: KeyContextHelp}
+	return MouseResult{Handled: true, Action: actionToKeyAction(a), Context: KeyContextHelp}
 }
 
 func (v *Viewer) handlePromptKey(ev *tcell.EventKey) KeyResult {

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -544,6 +544,10 @@ func (v *Viewer) HandleKeyResult(ev *tcell.EventKey) KeyResult {
 		v.ScrollUp(1)
 	case actionScrollDown:
 		v.ScrollDown(1)
+	case actionScrollUpStep:
+		v.ScrollUp(v.verticalScrollStep())
+	case actionScrollDownStep:
+		v.ScrollDown(v.verticalScrollStep())
 	case actionScrollLeft:
 		v.ScrollLeft(v.horizontalScrollStep())
 	case actionScrollRight:
@@ -710,6 +714,10 @@ func (v *Viewer) ScrollLeft(n int) {
 
 func (v *Viewer) horizontalScrollStep() int {
 	return max(1, min(8, v.bodyContentWidth()/4))
+}
+
+func (v *Viewer) verticalScrollStep() int {
+	return max(1, min(8, v.scrollBodyHeight()/8))
 }
 
 func (v *Viewer) halfHorizontalScrollStep() int {
@@ -2072,6 +2080,10 @@ func (v *Viewer) handleHelpKey(ev *tcell.EventKey) KeyResult {
 		v.helpOffset--
 	case actionScrollDown:
 		v.helpOffset++
+	case actionScrollUpStep:
+		v.helpOffset -= v.verticalScrollStep()
+	case actionScrollDownStep:
+		v.helpOffset += v.verticalScrollStep()
 	case actionScrollLeft:
 		v.helpColOffset -= v.horizontalScrollStep()
 	case actionScrollRight:

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -552,6 +552,10 @@ func (v *Viewer) HandleKeyResult(ev *tcell.EventKey) KeyResult {
 		v.ScrollLeft(1)
 	case actionScrollRightFine:
 		v.ScrollRight(1)
+	case actionHalfScreenLeft:
+		v.ScrollLeft(v.halfHorizontalScrollStep())
+	case actionHalfScreenRight:
+		v.ScrollRight(v.halfHorizontalScrollStep())
 	case actionHalfPageUp:
 		v.HalfPageUp()
 	case actionHalfPageDown:
@@ -708,6 +712,10 @@ func (v *Viewer) horizontalScrollStep() int {
 	return max(1, min(8, v.bodyContentWidth()/4))
 }
 
+func (v *Viewer) halfHorizontalScrollStep() int {
+	return max(v.bodyContentWidth()/2, 1)
+}
+
 // GoLineStart moves to the beginning of the current horizontal line in no-wrap mode.
 func (v *Viewer) GoLineStart() {
 	if v.cfg.WrapMode != layout.NoWrap {
@@ -717,30 +725,13 @@ func (v *Viewer) GoLineStart() {
 	v.relayout()
 }
 
-// GoLineEnd moves to the end of the current horizontal line in no-wrap mode.
+// GoLineEnd moves to the furthest reachable horizontal position in no-wrap mode.
 func (v *Viewer) GoLineEnd() {
 	if v.cfg.WrapMode != layout.NoWrap {
 		return
 	}
 	v.ensureLayout()
-	rowIndex := v.scrollableRowStartIndex() + v.rowOffset
-	if rowIndex < 0 || rowIndex >= len(v.layout.Rows) {
-		v.colOffset = v.maxColOffset()
-		v.relayout()
-		return
-	}
-	lineIndex := v.layout.Rows[rowIndex].LineIndex
-	if lineIndex < 0 || lineIndex >= len(v.layout.Lines) {
-		v.colOffset = v.maxColOffset()
-		v.relayout()
-		return
-	}
-	totalCells := v.layout.Lines[lineIndex].TotalCells + v.trailingMarkerCellWidth(lineIndex)
-	frozen := v.headerColumnWidth(v.rawContentWidth())
-	v.colOffset = max(totalCells-frozen-max(v.bodyContentWidth(), 1), 0)
-	if maxOffset := v.maxColOffset(); v.colOffset > maxOffset {
-		v.colOffset = maxOffset
-	}
+	v.colOffset = v.maxColOffset()
 	v.relayout()
 }
 
@@ -2089,6 +2080,10 @@ func (v *Viewer) handleHelpKey(ev *tcell.EventKey) KeyResult {
 		v.helpColOffset--
 	case actionScrollRightFine:
 		v.helpColOffset++
+	case actionHalfScreenLeft:
+		v.helpColOffset -= v.halfHorizontalScrollStep()
+	case actionHalfScreenRight:
+		v.helpColOffset += v.halfHorizontalScrollStep()
 	case actionPageUp:
 		v.helpOffset -= v.helpPageStep()
 	case actionPageDown:

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -111,6 +111,16 @@ func TestLessKeyMapHalfPageMoves(t *testing.T) {
 		t.Fatalf("Position().Row after Ctrl-U = %d, want %d", got, want)
 	}
 
+	v.HandleKey(keyRune("J"))
+	if got, want := v.Position().Row, 2; got != want {
+		t.Fatalf("Position().Row after J = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyRune("K"))
+	if got, want := v.Position().Row, 1; got != want {
+		t.Fatalf("Position().Row after K = %d, want %d", got, want)
+	}
+
 	v.HandleKey(keyKey(tcell.KeyCtrlD))
 	if got, want := v.Position().Row, 2; got != want {
 		t.Fatalf("Position().Row after KeyCtrlD = %d, want %d", got, want)
@@ -251,9 +261,9 @@ func TestLessKeyMapRefreshAliases(t *testing.T) {
 	}
 }
 
-func TestLessKeyMapHelpScrollsAndCloses(t *testing.T) {
+func TestLessKeyMapHelpScrollsLeftAndCloses(t *testing.T) {
 	doc := model.NewDocument(4)
-	if err := doc.Append([]byte("hello\nworld\n")); err != nil {
+	if err := doc.Append([]byte("abcdefghijklmnopqrstuvwxyz\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
 	}
 
@@ -261,14 +271,19 @@ func TestLessKeyMapHelpScrollsAndCloses(t *testing.T) {
 	v.SetSize(20, 4)
 	v.mode = modeHelp
 
-	v.HandleKey(keyKey(tcell.KeyDown))
-	if got, want := v.helpOffset, 1; got != want {
-		t.Fatalf("help offset after down = %d, want %d", got, want)
+	v.HandleKey(keyKey(tcell.KeyRight))
+	if got, want := v.helpColOffset, 5; got != want {
+		t.Fatalf("help col offset after Right = %d, want %d", got, want)
 	}
 
 	v.HandleKey(keyRune("h"))
+	if got, want := v.helpColOffset, 0; got != want {
+		t.Fatalf("help col offset after h = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyKey(tcell.KeyF1))
 	if got, want := v.mode, modeNormal; got != want {
-		t.Fatalf("mode after h = %v, want %v", got, want)
+		t.Fatalf("mode after F1 = %v, want %v", got, want)
 	}
 }
 
@@ -538,9 +553,29 @@ func TestLessKeyMapHelpUsesHorizontalNavigationKeys(t *testing.T) {
 		t.Fatalf("help col offset after Right = %d, want %d", got, want)
 	}
 
+	v.HandleKey(keyRune("h"))
+	if got, want := v.helpColOffset, 0; got != want {
+		t.Fatalf("help col offset after h = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyRune("l"))
+	if got, want := v.helpColOffset, 5; got != want {
+		t.Fatalf("help col offset after l = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyRune("L"))
+	if got, want := v.helpColOffset, 6; got != want {
+		t.Fatalf("help col offset after L = %d, want %d", got, want)
+	}
+
 	v.HandleKey(keyKeyMod(tcell.KeyLeft, tcell.ModShift))
-	if got, want := v.helpColOffset, 4; got != want {
+	if got, want := v.helpColOffset, 5; got != want {
 		t.Fatalf("help col offset after Shift-Left = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyRune("H"))
+	if got, want := v.helpColOffset, 0; got != want {
+		t.Fatalf("help col offset after H = %d, want %d", got, want)
 	}
 }
 
@@ -940,6 +975,27 @@ func TestHorizontalScrollStepUsesQuarterWidthCappedAtEight(t *testing.T) {
 	if got, want := v.colOffset, 0; got != want {
 		t.Fatalf("col offset after Left = %d, want %d", got, want)
 	}
+
+	v.HandleKey(keyKey(tcell.KeyRight))
+	v.HandleKey(keyRune("h"))
+	if got, want := v.colOffset, 0; got != want {
+		t.Fatalf("col offset after h = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyRune("l"))
+	if got, want := v.colOffset, 5; got != want {
+		t.Fatalf("col offset after l = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyRune("L"))
+	if got, want := v.colOffset, 6; got != want {
+		t.Fatalf("col offset after L = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyRune("H"))
+	if got, want := v.colOffset, 0; got != want {
+		t.Fatalf("col offset after H = %d, want %d", got, want)
+	}
 }
 
 func TestScrollRightDoesNotMoveWhenLineFullyVisible(t *testing.T) {
@@ -1019,7 +1075,7 @@ func TestShiftArrowKeysRemainFineHorizontalScroll(t *testing.T) {
 
 func TestGoLineStartAndEnd(t *testing.T) {
 	doc := model.NewDocument(4)
-	if err := doc.Append([]byte("abcdefghij\n")); err != nil {
+	if err := doc.Append([]byte("abc\nabcdefghijklmnopqrstuvwxyz\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
 	}
 
@@ -1027,7 +1083,7 @@ func TestGoLineStartAndEnd(t *testing.T) {
 	v.SetSize(5, 4)
 
 	v.GoLineEnd()
-	if got, want := v.colOffset, 5; got != want {
+	if got, want := v.colOffset, 21; got != want {
 		t.Fatalf("col offset after GoLineEnd = %d, want %d", got, want)
 	}
 
@@ -1037,7 +1093,7 @@ func TestGoLineStartAndEnd(t *testing.T) {
 	}
 
 	v.HandleKey(keyKey(tcell.KeyEnd))
-	if got, want := v.colOffset, 5; got != want {
+	if got, want := v.colOffset, 21; got != want {
 		t.Fatalf("col offset after End = %d, want %d", got, want)
 	}
 
@@ -1047,7 +1103,7 @@ func TestGoLineStartAndEnd(t *testing.T) {
 	}
 
 	v.HandleKey(keyRune("$"))
-	if got, want := v.colOffset, 5; got != want {
+	if got, want := v.colOffset, 21; got != want {
 		t.Fatalf("col offset after $ = %d, want %d", got, want)
 	}
 
@@ -2497,9 +2553,9 @@ func TestToggleHelpMode(t *testing.T) {
 	if got, want := v.mode, modeNormal; got != want {
 		t.Fatalf("initial mode = %v, want %v", got, want)
 	}
-	v.HandleKey(keyRune("h"))
+	v.HandleKey(keyKey(tcell.KeyF1))
 	if got, want := v.mode, modeHelp; got != want {
-		t.Fatalf("mode after h = %v, want %v", got, want)
+		t.Fatalf("mode after F1 = %v, want %v", got, want)
 	}
 	v.HandleKey(keyKey(tcell.KeyEscape))
 	if got, want := v.mode, modeNormal; got != want {
@@ -2520,6 +2576,15 @@ func TestViewerUsesCustomTextBundle(t *testing.T) {
 
 	if got, want := v.text.HelpTitle, "Ayuda"; got != want {
 		t.Fatalf("help title = %q, want %q", got, want)
+	}
+}
+
+func TestViewerDefaultHelpCloseUsesF1(t *testing.T) {
+	doc := model.NewDocument(4)
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap})
+
+	if got, want := v.text.HelpClose, "Esc/q/F1 close"; got != want {
+		t.Fatalf("help close = %q, want %q", got, want)
 	}
 }
 

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -5,6 +5,7 @@ package view
 
 import (
 	"runtime"
+	"strconv"
 	"strings"
 	"testing"
 	"unicode/utf8"
@@ -170,6 +171,44 @@ func TestLessKeyMapSingleLineAliases(t *testing.T) {
 				t.Fatalf("Position().Row after %s = %d, want %d", tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestLessKeyMapArrowKeysUseVerticalStepAndShiftForFineScroll(t *testing.T) {
+	doc := model.NewDocument(4)
+	var b strings.Builder
+	for i := 1; i <= 40; i++ {
+		b.WriteString("line")
+		b.WriteString(strconv.Itoa(i))
+		b.WriteByte('\n')
+	}
+	if err := doc.Append([]byte(b.String())); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 17)
+
+	step := v.verticalScrollStep()
+
+	v.HandleKey(keyKey(tcell.KeyDown))
+	if got, want := v.Position().Row, 1+step; got != want {
+		t.Fatalf("Position().Row after Down = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyKeyMod(tcell.KeyDown, tcell.ModShift))
+	if got, want := v.Position().Row, 2+step; got != want {
+		t.Fatalf("Position().Row after Shift-Down = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyKey(tcell.KeyUp))
+	if got, want := v.Position().Row, 2; got != want {
+		t.Fatalf("Position().Row after Up = %d, want %d", got, want)
+	}
+
+	v.HandleKey(keyKeyMod(tcell.KeyUp, tcell.ModShift))
+	if got, want := v.Position().Row, 1; got != want {
+		t.Fatalf("Position().Row after Shift-Up = %d, want %d", got, want)
 	}
 }
 
@@ -1107,9 +1146,32 @@ func TestGoLineStartAndEnd(t *testing.T) {
 		t.Fatalf("col offset after $ = %d, want %d", got, want)
 	}
 
+	v.HandleKey(keyRuneMod("$", tcell.ModShift))
+	if got, want := v.colOffset, 21; got != want {
+		t.Fatalf("col offset after shifted $ = %d, want %d", got, want)
+	}
+
 	v.HandleKey(keyRune("0"))
 	if got, want := v.colOffset, 0; got != want {
 		t.Fatalf("col offset after 0 = %d, want %d", got, want)
+	}
+}
+
+func TestHelpShiftedDollarStillGoesToLineEnd(t *testing.T) {
+	doc := model.NewDocument(4)
+	v := New(doc, Config{
+		TabWidth: 4,
+		WrapMode: layout.NoWrap,
+		Text: Text{
+			HelpBody: "abcdefghijklmnopqrstuv\nabcdefghijklmnopqrstuvwxyz0123456789\n",
+		},
+	})
+	v.SetSize(20, 4)
+	v.mode = modeHelp
+
+	v.HandleKey(keyRuneMod("$", tcell.ModShift))
+	if got, want := v.helpColOffset, 2; got != want {
+		t.Fatalf("help col offset after shifted $ = %d, want %d", got, want)
 	}
 }
 

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -189,15 +189,13 @@ func TestLessKeyMapArrowKeysUseVerticalStepAndShiftForFineScroll(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 17)
 
-	step := v.verticalScrollStep()
-
 	v.HandleKey(keyKey(tcell.KeyDown))
-	if got, want := v.Position().Row, 1+step; got != want {
+	if got, want := v.Position().Row, 3; got != want {
 		t.Fatalf("Position().Row after Down = %d, want %d", got, want)
 	}
 
 	v.HandleKey(keyKeyMod(tcell.KeyDown, tcell.ModShift))
-	if got, want := v.Position().Row, 2+step; got != want {
+	if got, want := v.Position().Row, 4; got != want {
 		t.Fatalf("Position().Row after Shift-Down = %d, want %d", got, want)
 	}
 
@@ -302,11 +300,14 @@ func TestLessKeyMapRefreshAliases(t *testing.T) {
 
 func TestLessKeyMapHelpScrollsLeftAndCloses(t *testing.T) {
 	doc := model.NewDocument(4)
-	if err := doc.Append([]byte("abcdefghijklmnopqrstuvwxyz\n")); err != nil {
-		t.Fatalf("Append failed: %v", err)
-	}
-
-	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v := New(doc, Config{
+		TabWidth:   4,
+		WrapMode:   layout.NoWrap,
+		ShowStatus: true,
+		Text: Text{
+			HelpBody: "abcdefghijklmnopqrstuvwxyz\n",
+		},
+	})
 	v.SetSize(20, 4)
 	v.mode = modeHelp
 
@@ -323,6 +324,36 @@ func TestLessKeyMapHelpScrollsLeftAndCloses(t *testing.T) {
 	v.HandleKey(keyKey(tcell.KeyF1))
 	if got, want := v.mode, modeNormal; got != want {
 		t.Fatalf("mode after F1 = %v, want %v", got, want)
+	}
+}
+
+func TestLessKeyMapHelpArrowKeysIgnoreDocumentHeaderLines(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("header\nbody\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+	var help strings.Builder
+	for i := 1; i <= 30; i++ {
+		help.WriteString("line")
+		help.WriteString(strconv.Itoa(i))
+		help.WriteByte('\n')
+	}
+
+	v := New(doc, Config{
+		TabWidth:    4,
+		WrapMode:    layout.NoWrap,
+		ShowStatus:  true,
+		HeaderLines: 6,
+		Text: Text{
+			HelpBody: help.String(),
+		},
+	})
+	v.SetSize(20, 17)
+	v.mode = modeHelp
+
+	v.HandleKey(keyKey(tcell.KeyDown))
+	if got, want := v.helpOffset, 2; got != want {
+		t.Fatalf("help offset after Down = %d, want %d", got, want)
 	}
 }
 

--- a/keymap.go
+++ b/keymap.go
@@ -51,6 +51,10 @@ const (
 	KeyActionScrollLeftFine
 	// KeyActionScrollRightFine scrolls right by one cell.
 	KeyActionScrollRightFine
+	// KeyActionHalfScreenLeft scrolls left by roughly half the viewport width.
+	KeyActionHalfScreenLeft
+	// KeyActionHalfScreenRight scrolls right by roughly half the viewport width.
+	KeyActionHalfScreenRight
 	// KeyActionHalfPageUp scrolls up by roughly half a page.
 	KeyActionHalfPageUp
 	// KeyActionHalfPageDown scrolls down by roughly half a page.

--- a/keymap.go
+++ b/keymap.go
@@ -69,7 +69,7 @@ const (
 	KeyActionPageDown
 	// KeyActionGoLineStart jumps to the beginning of the current horizontal line.
 	KeyActionGoLineStart
-	// KeyActionGoLineEnd jumps to the end of the current horizontal line.
+	// KeyActionGoLineEnd jumps to the furthest reachable horizontal position.
 	KeyActionGoLineEnd
 	// KeyActionGoTop jumps to the top of the document.
 	KeyActionGoTop

--- a/keymap.go
+++ b/keymap.go
@@ -43,6 +43,10 @@ const (
 	KeyActionScrollUp
 	// KeyActionScrollDown scrolls down by one row.
 	KeyActionScrollDown
+	// KeyActionScrollUpStep scrolls up by a coarse vertical navigation step.
+	KeyActionScrollUpStep
+	// KeyActionScrollDownStep scrolls down by a coarse vertical navigation step.
+	KeyActionScrollDownStep
 	// KeyActionScrollLeft scrolls left by a horizontal navigation step.
 	KeyActionScrollLeft
 	// KeyActionScrollRight scrolls right by a horizontal navigation step.

--- a/pager.go
+++ b/pager.go
@@ -646,6 +646,10 @@ func toInternalKeyAction(a KeyAction) iview.KeyAction {
 		return iview.KeyActionScrollUp
 	case KeyActionScrollDown:
 		return iview.KeyActionScrollDown
+	case KeyActionScrollUpStep:
+		return iview.KeyActionScrollUpStep
+	case KeyActionScrollDownStep:
+		return iview.KeyActionScrollDownStep
 	case KeyActionScrollLeft:
 		return iview.KeyActionScrollLeft
 	case KeyActionScrollRight:
@@ -654,6 +658,10 @@ func toInternalKeyAction(a KeyAction) iview.KeyAction {
 		return iview.KeyActionScrollLeftFine
 	case KeyActionScrollRightFine:
 		return iview.KeyActionScrollRightFine
+	case KeyActionHalfScreenLeft:
+		return iview.KeyActionHalfScreenLeft
+	case KeyActionHalfScreenRight:
+		return iview.KeyActionHalfScreenRight
 	case KeyActionHalfPageUp:
 		return iview.KeyActionHalfPageUp
 	case KeyActionHalfPageDown:

--- a/pager.go
+++ b/pager.go
@@ -421,7 +421,7 @@ func (p *Pager) GoLineStart() {
 	p.viewer.GoLineStart()
 }
 
-// GoLineEnd moves to the end of the current horizontal line in no-wrap mode.
+// GoLineEnd moves to the furthest reachable horizontal position in no-wrap mode.
 func (p *Pager) GoLineEnd() {
 	p.viewer.GoLineEnd()
 }

--- a/pager_test.go
+++ b/pager_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	iview "github.com/gdamore/goless/internal/view"
 	"github.com/gdamore/tcell/v3"
 	"github.com/gdamore/tcell/v3/color"
 	"github.com/gdamore/tcell/v3/vt"
@@ -526,6 +527,27 @@ func TestPagerHandleMouseResultHelpContext(t *testing.T) {
 	}
 	if got, want := result.Context, HelpKeyContext; got != want {
 		t.Fatalf("HandleMouseResult(WheelDown).Context = %v, want %v", got, want)
+	}
+}
+
+func TestToInternalKeyActionMapsExtendedScrollActions(t *testing.T) {
+	tests := []struct {
+		name string
+		in   KeyAction
+		want iview.KeyAction
+	}{
+		{name: "scroll up step", in: KeyActionScrollUpStep, want: iview.KeyActionScrollUpStep},
+		{name: "scroll down step", in: KeyActionScrollDownStep, want: iview.KeyActionScrollDownStep},
+		{name: "half screen left", in: KeyActionHalfScreenLeft, want: iview.KeyActionHalfScreenLeft},
+		{name: "half screen right", in: KeyActionHalfScreenRight, want: iview.KeyActionHalfScreenRight},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := toInternalKeyAction(tt.in); got != tt.want {
+				t.Fatalf("toInternalKeyAction(%v) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/site/content/user-manual/getting-started.md
+++ b/site/content/user-manual/getting-started.md
@@ -52,6 +52,7 @@ The initial format is:
   "hidden": false,
   "line-numbers": false,
   "live-links": false,
+  "mouse": true,
   "secure": false
 }
 ```
@@ -60,6 +61,9 @@ Use `goless --default-config` to print the built-in JSON and redirect it into a
 starter config file.
 
 Command-line flags still win over config values for a single invocation.
+
+Set `"mouse": false` or pass `--no-mouse` if you want the
+standalone program to leave terminal text selection and native scrolling alone.
 
 ## What Users Need First
 

--- a/site/content/user-manual/getting-started.md
+++ b/site/content/user-manual/getting-started.md
@@ -60,7 +60,9 @@ The initial format is:
 Use `goless --default-config` to print the built-in JSON and redirect it into a
 starter config file.
 
-Command-line flags still win over config values for a single invocation.
+Command-line flags still win over config values for a single invocation, so
+`goless --mouse file.txt` temporarily enables mouse capture even when the config
+sets `"mouse": false`.
 
 Set `"mouse": false` or pass `--no-mouse` if you want the
 standalone program to leave terminal text selection and native scrolling alone.

--- a/site/content/user-manual/navigation-and-search.md
+++ b/site/content/user-manual/navigation-and-search.md
@@ -8,7 +8,9 @@ The built-in less-like key group already gives the future user manual a strong o
 
 ## Core Navigation
 
-- `j` and `k` or the arrow keys to move line by line
+- `j` and `k` to move line by line
+- `Up` and `Down` to move by a coarse vertical screen step
+- `Shift-Up` and `Shift-Down` to move line by line with the cursor keys
 - `space` and `b` to page down and up
 - `w` also pages up in the built-in less-like key group
 - `g` and `G` to jump to the top or bottom

--- a/text.go
+++ b/text.go
@@ -81,7 +81,7 @@ type Text struct {
 func DefaultText() Text {
 	return Text{
 		HelpTitle: "Help",
-		HelpClose: "Esc/q/H/F1 close",
+		HelpClose: "Esc/q/F1 close",
 		HelpBody:  defaults.HelpBody,
 		StatusSearchInfo: func(query string, current, total int) string {
 			return fmt.Sprintf("/%s %d/%d", query, current, total)

--- a/text_test.go
+++ b/text_test.go
@@ -1,0 +1,12 @@
+// Copyright 2026 Garrett D'Amore
+// SPDX-License-Identifier: Apache-2.0
+
+package goless
+
+import "testing"
+
+func TestDefaultTextHelpCloseUsesF1(t *testing.T) {
+	if got, want := DefaultText().HelpClose, "Esc/q/F1 close"; got != want {
+		t.Fatalf("DefaultText().HelpClose = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
Enable easier cursor movement, and stop stealing "h" for help.  Allow the ability to disable the mouse capture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  - Optional mouse input control (enable/disable via --mouse / --no-mouse and config)
  - Half-screen horizontal scrolling (H / L)
  - Coarse vertical "screen step" scrolling (Up / Down) with Shift for fine line-by-line moves

* **Changes**
  - Help now toggles only with F1 (removed h from defaults)
  - Default built-in config and docs include "mouse": true; guidance added for preserving terminal selection

* **Tests & Docs**
  - Updated tests, examples, help text, and user manual to reflect key and mouse behavior changes
<!-- end of auto-generated comment: release notes by coderabbit.ai -->