### PR TITLE
fix: Add support for empty chrome

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Common options are:
 - `KeyGroup`: `LessKeyGroup` or `EmptyKeyGroup`
 - `UnbindKeys` and `KeyBindings`: remove or prepend bindings in normal, help,
   or prompt contexts
-- `Chrome`: optional frame/title styling plus title alignment and status/prompt style slots
+- `Chrome`: optional frame/title styling plus title alignment and status/prompt style slots; frame glyphs are rendered exactly as configured, including intentional empty strings
 - `Chrome.LineNumberStyle`: optional style for the adaptive line-number gutter
 - `Chrome.HeaderStyle`: optional style for fixed header rows and columns
 - `Text`: override help text, status text, prompt text, and UI strings

--- a/chrome.go
+++ b/chrome.go
@@ -18,7 +18,8 @@ const (
 )
 
 // Frame defines the glyphs used to draw an optional border around the pager
-// body. An all-zero Frame disables border drawing.
+// body. An all-zero Frame disables border drawing. When a frame is enabled,
+// each field is rendered exactly as configured; empty strings remain empty.
 type Frame struct {
 	// Horizontal is the glyph repeated across the top and bottom frame edges.
 	Horizontal string
@@ -35,6 +36,8 @@ type Frame struct {
 }
 
 // Chrome configures optional decorative chrome around the pager body.
+// Frame glyphs are drawn exactly as configured, so embedders can intentionally
+// leave pieces blank when that suits the design.
 type Chrome struct {
 	// Title is rendered into the top border area when a frame is enabled.
 	Title string

--- a/internal/view/chrome.go
+++ b/internal/view/chrome.go
@@ -18,7 +18,8 @@ const (
 )
 
 // Frame defines the glyphs used to draw an optional border around the viewer
-// body. An all-zero Frame disables border drawing.
+// body. An all-zero Frame disables border drawing. When a frame is enabled,
+// each field is rendered exactly as configured.
 type Frame struct {
 	Horizontal  string
 	Vertical    string

--- a/internal/view/viewer.go
+++ b/internal/view/viewer.go
@@ -1342,9 +1342,9 @@ func (v *Viewer) drawFrame(screen tcell.Screen, title string) {
 	borderStyle := v.cfg.Chrome.BorderStyle
 	titleStyle := v.cfg.Chrome.TitleStyle
 	if v.width == 1 {
-		screen.PutStrStyled(0, topY, fallback(frame.TopLeft, frame.Horizontal, frame.Vertical), borderStyle)
+		screen.PutStrStyled(0, topY, frame.TopLeft, borderStyle)
 		if bottomY != topY {
-			screen.PutStrStyled(0, bottomY, fallback(frame.BottomLeft, frame.Horizontal, frame.Vertical), borderStyle)
+			screen.PutStrStyled(0, bottomY, frame.BottomLeft, borderStyle)
 		}
 		return
 	}
@@ -1357,7 +1357,7 @@ func (v *Viewer) drawFrame(screen tcell.Screen, title string) {
 		screen.PutStrStyled(x, topY, label, titleStyle)
 	}
 
-	side := fallback(frame.Vertical, "│")
+	side := frame.Vertical
 	for y := topY + 1; y < bottomY; y++ {
 		screen.PutStrStyled(0, y, side, borderStyle)
 		screen.PutStrStyled(v.width-1, y, side, borderStyle)
@@ -2553,22 +2553,10 @@ func frameLine(width int, left, fill, right string) string {
 		return ""
 	}
 	if width == 1 {
-		return fallback(left, fill, right)
+		return left
 	}
 
-	left = fallback(left, fill, " ")
-	fill = fallback(fill, " ")
-	right = fallback(right, fill, " ")
 	return left + strings.Repeat(fill, width-2) + right
-}
-
-func fallback(values ...string) string {
-	for _, v := range values {
-		if v != "" {
-			return v
-		}
-	}
-	return ""
 }
 
 func frameTitleLabel(title string, width int, align TitleAlign) (label string, x int) {

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -4173,6 +4173,48 @@ func TestDrawFrameInsetsContentAndRendersTitle(t *testing.T) {
 	}
 }
 
+func TestDrawFramePreservesExplicitEmptySides(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("hi\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{
+		TabWidth: 4,
+		WrapMode: layout.NoWrap,
+		Chrome: Chrome{
+			Title: "Doc",
+			Frame: Frame{
+				Horizontal:  "─",
+				Vertical:    "",
+				TopLeft:     "╭",
+				TopRight:    "╮",
+				BottomLeft:  "╰",
+				BottomRight: "╯",
+			},
+		},
+	})
+	v.SetSize(10, 4)
+
+	_, screen := newMockScreen(t, 10, 4)
+	defer screen.Fini()
+
+	v.Draw(screen)
+
+	if got := cellRune(screen, 0, 0); got != '╭' {
+		t.Fatalf("top-left border rune = %q, want %q", got, '╭')
+	}
+	if got := cellRune(screen, 0, 1); got != ' ' {
+		t.Fatalf("left border rune = %q, want empty", got)
+	}
+	if got := cellRune(screen, 1, 1); got != 'h' {
+		t.Fatalf("content rune = %q, want %q", got, 'h')
+	}
+	if got := cellRune(screen, 0, 2); got != ' ' {
+		t.Fatalf("left border rune on second body row = %q, want empty", got)
+	}
+}
+
 func TestDrawFrameUsesBorderAndTitleStyles(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("hi\n")); err != nil {

--- a/site/content/developer-guide/embedding-basics.md
+++ b/site/content/developer-guide/embedding-basics.md
@@ -31,6 +31,9 @@ func runPager(screen tcell.Screen, input io.Reader) error {
 }
 ```
 
+Frame glyphs are rendered exactly as configured, so you can leave a side or
+corner blank by setting that field to `""` instead of relying on a fallback.
+
 The simplest useful embedding loop has four steps:
 
 - load the document content

--- a/site/content/developer-guide/recipes.md
+++ b/site/content/developer-guide/recipes.md
@@ -26,6 +26,9 @@ pager := goless.New(
 Use the preset as a starting point, not as a shared mutable singleton. Copy it
 before changing any fields.
 
+Frame glyphs are rendered exactly as configured, so if you want an empty side
+or corner, set that field to `""` explicitly.
+
 ## How Do I Keep Hyperlinks Inert Until I Trust Them?
 
 Return a decision with `Live: false` by default and opt in only for URLs your


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Frame glyphs now render exactly as configured, preserving intentional empty strings instead of applying fallback substitutions.

* **Documentation**
  * Updated documentation to clarify that frame elements are rendered precisely as set, including blank segments.

* **Tests**
  * Added test coverage for explicit empty frame segments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->