### PR TITLE
Refactor commands and flags.

### DIFF
--- a/LESS_COMPATIBILITY.md
+++ b/LESS_COMPATIBILITY.md
@@ -36,8 +36,8 @@ Already compatible or close enough:
 
 Useful, but intentionally different:
 
-- `:set ...` commands are custom pager commands, not `less` option toggles
-- search mode and case mode are exposed directly with `F2`, `F3`, and `:set`
+- direct pager commands such as `:wrap`, `:nowrap`, `:number`, `:nonumber`, `:markers`, `:nomarkers`, and `:match [auto|nocase|case] [sub|word|regex]` replace `:set ...` style option toggles
+- search mode and case mode are exposed directly with `F2`, `F3`, and the command language
 
 Notable gaps:
 
@@ -92,8 +92,8 @@ Compatible today:
 - `+/pattern`
 - multiple files plus explicit `-` for stdin
 
-Custom flags such as `-preset`, `-chrome`, `-hidden`, `-render`, and
-`-live-links` are fine; they do not block familiarity as long as common `less`
+Custom flags such as `-preset`, `-chrome`, `--markers`, `--literal`, and
+`--live-links` are fine; they do not block familiarity as long as common `less`
 habits also work.
 
 ## Recommended Changes

--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ By default, literal search uses smart-case behavior:
 
 The built-in pager UI exposes search mode controls directly:
 
-- `F2` in the bundled less-like key group cycles `smart -> case -> nocase`
+- `F2` in the bundled less-like key group cycles `auto -> case -> nocase`
 - `F3` in the bundled less-like key group cycles `sub -> word -> regex`
 - the search prompt always shows the current search mode
 - the status bar shows search mode when a search is active or the search settings are non-default
@@ -245,13 +245,14 @@ The built-in pager UI exposes search mode controls directly:
   These are 1-based logical coordinates rather than wrapped visual row numbers
 - the built-in status bar reserves an EOF slot and shows `∎` when the end of the document is visible
 - the right side of the status bar adds contextual wrap/scroll glyphs such as `↪` and `⇆`
-- `:set number|nonumber|invnumber` is available as a fallback
-- `:set wrap|nowrap|invwrap` is available as a fallback
-- `:set list|nolist|invlist` is available as a fallback
-- `:set squeeze|nosqueeze|invsqueeze` is available as a fallback
-- `:set tabstop=<n>`, `:set pinlines=<n>`, and `:set pincols=<n>` are available as fallbacks
-- `:set ignorecase`, `:set noignorecase`, `:set smartcase`, and `:set nosmartcase` control search case
-- `:set searchcase=smart|case|nocase` and `:set searchmode=sub|word|regex` are available as explicit fallbacks
+- `:number` / `:nonumber` control line numbers
+- `:wrap` / `:nowrap` control soft wrapping
+- `:markers` / `:nomarkers` control hidden-character markers
+- `:squeeze` / `:nosqueeze` control adjacent blank-line collapsing
+- `:tabs <n>` sets tab width
+- `:pin [rows=<n>] [cols=<n>]` pins the top rows and/or left columns
+- `:match [auto|nocase|case] [sub|word|regex]` controls search case and matching
+- `:help` opens the built-in help overlay
 - invalid regexes stay in the search prompt and are marked visibly until fixed
 
 `SqueezeBlankLines` is a view-time policy: raw input stays unchanged and
@@ -347,9 +348,9 @@ Program flags:
 - `-x n` to set tab width
 - `-theme dark|light|plain|pretty`
 - `-chrome auto|none|single|rounded`
-- `-hidden`
-- `-live-links`
-- `-render hybrid|literal|presentation`
+- `--markers` / `--no-markers` to show or hide hidden-character markers
+- `--live-links`
+- `--literal` / `--no-literal` to show escape sequences literally or interpret supported escapes
 - `-s` or `-squeeze` to collapse repeated blank lines in the current view
 - `-title text`
 - optional `+line` or `+/pattern` startup directive before paths
@@ -380,6 +381,9 @@ The initial config schema is intentionally small:
   "secure": false
 }
 ```
+
+The JSON config still uses the `"hidden"` field name; the CLI exposes the same
+setting as `--markers` / `--no-markers`.
 
 Use `goless --default-config` to print that built-in config and redirect it into
 `goless/config.json` or another starter file.
@@ -421,10 +425,18 @@ The default key group is intentionally less-like. Common bindings include:
 - `:license` to show the bundled Apache license in an overlay
 - `:Q` as an additional quit command
 - `=` or `Ctrl-G` to show current file/session status in the standalone program
-- `:set number`, `:set wrap`, `:set list`, and `:set squeeze` plus `no...` and `inv...` forms
-- `:set tabstop=<n>`, `:set pinlines=<n>`, and `:set pincols=<n>`
-- `:set ignorecase`, `:set noignorecase`, `:set smartcase`, and `:set nosmartcase`
-- `:set searchcase=smart|case|nocase` and `:set searchmode=sub|word|regex`
+- `:number`                              show line numbers
+- `:nonumber`                            hide line numbers
+- `:wrap`                                soft-wrap long lines
+- `:nowrap`                              disable soft wrapping
+- `:markers`                             show hidden-character markers
+- `:nomarkers`                           hide hidden-character markers
+- `:squeeze`                             collapse adjacent blank lines
+- `:nosqueeze`                           keep blank lines
+- `:tabs <n>`                           set tab width
+- `:pin [rows=<n>] [cols=<n>]`          pin the top rows and/or left columns
+- `:match [auto|nocase|case] [sub|word|regex]`  control search case and matching
+- `:help`                               show the built-in help overlay
 - `F` to enable follow mode
 - `Ctrl-X` or `Ctrl-C` to stop following without quitting
 - `F1` to toggle help

--- a/cmd/goless/config.go
+++ b/cmd/goless/config.go
@@ -115,7 +115,7 @@ func loadProgramConfigAtPath(path string, optional bool) (programConfig, error) 
 
 func applyProgramConfig(opts programOptions, cfg programConfig) programOptions {
 	if cfg.Hidden != nil {
-		opts.hidden = *cfg.Hidden
+		opts.markers = *cfg.Hidden
 	}
 	if cfg.LineNumbers != nil {
 		opts.lineNumbers = *cfg.LineNumbers

--- a/cmd/goless/config_test.go
+++ b/cmd/goless/config_test.go
@@ -116,8 +116,8 @@ func TestParseProgramFlagsLoadsDefaultProgramConfig(t *testing.T) {
 	if got, want := opts.presetName, "dark"; got != want {
 		t.Fatalf("theme = %q, want %q", got, want)
 	}
-	if !opts.hidden {
-		t.Fatal("hidden = false, want true from config")
+	if !opts.markers {
+		t.Fatal("markers = false, want true from config")
 	}
 	if !opts.lineNumbers {
 		t.Fatal("lineNumbers = false, want true from config")
@@ -140,15 +140,15 @@ func TestParseProgramFlagsCLIOverridesProgramConfig(t *testing.T) {
 	setTestProgramConfigHome(t)
 	writeDefaultTestProgramConfig(t, `{"theme":"dark","hidden":true,"line-numbers":true,"live-links":true,"mouse":false,"secure":true}`)
 
-	opts, _, err := parseProgramFlags([]string{"-theme", "light", "-N=false", "-hidden=false", "-live-links=false", "-mouse=true", "-secure=false"})
+	opts, _, err := parseProgramFlags([]string{"-theme", "light", "-N=false", "-markers=false", "-live-links=false", "-mouse=true", "-secure=false"})
 	if err != nil {
 		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
 	if got, want := opts.presetName, "light"; got != want {
 		t.Fatalf("theme = %q, want %q", got, want)
 	}
-	if opts.hidden {
-		t.Fatal("hidden = true, want CLI override false")
+	if opts.markers {
+		t.Fatal("markers = true, want CLI override false")
 	}
 	if opts.lineNumbers {
 		t.Fatal("lineNumbers = true, want CLI override false")
@@ -189,8 +189,8 @@ func TestParseProgramFlagsExplicitConfigOverridesDefaultPath(t *testing.T) {
 	if got, want := opts.presetName, "light"; got != want {
 		t.Fatalf("theme = %q, want %q", got, want)
 	}
-	if !opts.hidden {
-		t.Fatal("hidden = false, want true from explicit config")
+	if !opts.markers {
+		t.Fatal("markers = false, want true from explicit config")
 	}
 	if opts.lineNumbers {
 		t.Fatal("lineNumbers = true, want false because explicit config replaces default config source")
@@ -212,8 +212,8 @@ func TestParseProgramFlagsLoadsEnvProgramConfig(t *testing.T) {
 	if got, want := opts.presetName, "light"; got != want {
 		t.Fatalf("theme = %q, want %q", got, want)
 	}
-	if !opts.hidden {
-		t.Fatal("hidden = false, want true from GOLESS_CONFIG")
+	if !opts.markers {
+		t.Fatal("markers = false, want true from GOLESS_CONFIG")
 	}
 	if !opts.lineNumbers {
 		t.Fatal("lineNumbers = false, want true from GOLESS_CONFIG")
@@ -233,8 +233,8 @@ func TestParseProgramFlagsEnvConfigOverridesDefaultPath(t *testing.T) {
 	if got, want := opts.presetName, "light"; got != want {
 		t.Fatalf("theme = %q, want %q", got, want)
 	}
-	if !opts.hidden {
-		t.Fatal("hidden = false, want true from GOLESS_CONFIG")
+	if !opts.markers {
+		t.Fatal("markers = false, want true from GOLESS_CONFIG")
 	}
 }
 
@@ -254,8 +254,8 @@ func TestParseProgramFlagsExplicitConfigOverridesEnvConfig(t *testing.T) {
 	if got, want := opts.presetName, "light"; got != want {
 		t.Fatalf("theme = %q, want %q", got, want)
 	}
-	if opts.hidden {
-		t.Fatal("hidden = true, want false from explicit config")
+	if opts.markers {
+		t.Fatal("markers = true, want false from explicit config")
 	}
 	if !opts.lineNumbers {
 		t.Fatal("lineNumbers = false, want true from explicit config")

--- a/cmd/goless/help.txt
+++ b/cmd/goless/help.txt
@@ -9,32 +9,32 @@
   F4                  cycle themes
 
 [1;4mNavigation[0m
-  ↓                   move forward by a screen step
-  ↑                   move backward by a screen step
+  ↓                        move forward by a screen step
+  ↑                        move backward by a screen step
   Shift+↓ e j Enter ^E ^N  move one line forward
   Shift+↑ k y ^Y ^K ^P     move one line backward
-  f Space PgDn ^F ^V  forward one page
-  PgUp ^B b w         backward one page
-  d ^D J              forward half page
-  u ^U K              backward half page
-  Home 0              jump to line start
-  End $               jump to far right
-  g <                 jump to top
-  G >                 jump to bottom
-  ← h                 scroll horizontally left
-  → l                 scroll horizontally right
-  H                   scroll left half screen
-  L                   scroll right half screen
-  Shift+← Shift+→     scroll horizontally by 1
-  W                   toggle wrap
-  F                   follow the end of the document
-  ^X ^C               stop following
+  f Space PgDn ^F ^V       forward one page
+  PgUp ^B b w              backward one page
+  d ^D J                   forward half page
+  u ^U K                   backward half page
+  Home 0                   jump to line start
+  End $                    jump to far right
+  g <                      jump to top
+  G >                      jump to bottom
+  ← h                      scroll horizontally left
+  → l                      scroll horizontally right
+  H                        scroll left half screen
+  L                        scroll right half screen
+  Shift+← Shift+→          scroll horizontally by 1
+  W                        toggle wrap
+  F                        follow the end of the document
+  ^X ^C                    stop following
 
 [1;4mSearch[0m
   /                   search forward
   ?                   search backward
   n N                 next/previous match
-  F2                  cycle case mode (smart/case/nocase)
+  F2                  cycle case mode (auto/case/nocase)
   F3                  cycle match mode (substring/word/regex)
 
 [1;4mSave Prompt[0m
@@ -54,18 +54,22 @@
   ↑ ↓                 recall prompt history
 
 [1;4mCommands[0m
-  :123                    jump to line 123
-  :50%                    jump to 50%
-  :set number             show line numbers
-  :set wrap               soft-wrap long lines
-  :set list               show hidden-character markers
-  :set squeeze            collapse adjacent blank lines
-  :set tabstop=[3mnum[0m        set tab width
-  :set pinlines=[3mnum[0m       pin top lines
-  :set pincols=[3mnum[0m        pin left columns
-  :set ignorecase         search without case sensitivity
-  :set smartcase          search smart-case
-  :set searchmode=[3mmode[0m    set match mode (sub|word|regex)
-  :reload                 reload current file/input
-  :save [--view] [--mono] [3mpath[0m
-  :license                show the bundled Apache license
+  :123                          jump to line 123
+  :50%                          jump to 50%
+  :number                       show line numbers
+  :nonumber                     hide line numbers
+  :wrap                         soft-wrap long lines
+  :nowrap                       disable soft wrapping
+  :markers                      show hidden-character markers
+  :nomarkers                    hide hidden-character markers
+  :squeeze                      collapse adjacent blank lines
+  :nosqueeze                    keep blank lines
+  :tabs 8                       set tab width to 8
+  :pin rows=6                   pin top 6 rows
+  :pin cols=10                  pin left 10 columns
+  :match [auto|nocase|case]     set search case-sensitivity
+  :match [sub|word|regex]       set search mode
+  :help                         show the built-in help overlay
+  :reload                       reload current file/input
+  :save [--view] [--mono] [3mpath[0m  save current file
+  :license                      show the bundled Apache license

--- a/cmd/goless/main.go
+++ b/cmd/goless/main.go
@@ -41,17 +41,17 @@ const programDefaultTheme = "pretty"
 type programOptions struct {
 	chromeName        string
 	configPath        string
-	hidden            bool
 	ignoredChopLines  bool
 	ignoredRawControl bool
 	lineNumbers       bool
 	liveLinks         bool
 	mouseCapture      bool
+	markers           bool
 	presetName        string
 	quitAtEOF         bool
 	quitAtEOFFirst    bool
 	quitIfOneScreen   bool
-	renderName        string
+	literal           bool
 	searchCaseMode    goless.SearchCaseMode
 	secure            bool
 	showDefaultConfig bool
@@ -157,9 +157,9 @@ func run() error {
 		return writeDefaultProgramConfig(os.Stdout)
 	}
 
-	renderMode, err := programRenderMode(opts.renderName)
-	if err != nil {
-		return err
+	renderMode := goless.RenderHybrid
+	if opts.literal {
+		renderMode = goless.RenderLiteral
 	}
 	preset, err := programPreset(opts.presetName)
 	if err != nil {
@@ -247,7 +247,7 @@ func run() error {
 			renderMode,
 			preset,
 			session.chrome(chromeCfg),
-			opts.hidden,
+			opts.markers,
 			opts.liveLinks,
 			opts.lineNumbers,
 			opts.searchCaseMode,
@@ -364,8 +364,8 @@ func run() error {
 				break
 			}
 			if event.Key() == tcell.KeyF5 {
-				opts.hidden = !opts.hidden
-				pager.SetVisualization(programVisualization(opts.hidden))
+				opts.markers = !opts.markers
+				pager.SetVisualization(programVisualization(opts.markers))
 				break
 			}
 			before := pager.Position()
@@ -486,7 +486,6 @@ func parseProgramFlags(args []string) (programOptions, []string, error) {
 	opts := programOptions{
 		presetName:     programDefaultTheme,
 		chromeName:     "auto",
-		renderName:     "hybrid",
 		searchCaseMode: goless.SearchSmartCase,
 		mouseCapture:   true,
 		tabWidth:       8,
@@ -523,27 +522,31 @@ func parseProgramFlags(args []string) (programOptions, []string, error) {
 	fs.BoolVar(&opts.lineNumbers, "N", opts.lineNumbers, "show line numbers")
 	fs.BoolVar(&opts.ignoredRawControl, "R", opts.ignoredRawControl, "accepted as a less compatibility no-op")
 	fs.BoolVar(&opts.ignoredChopLines, "S", opts.ignoredChopLines, "accepted as a less compatibility no-op")
-	fs.BoolVar(&opts.hidden, "hidden", opts.hidden, "show tabs, line endings, carriage returns, and EOF markers")
+	fs.BoolVar(&opts.markers, "markers", opts.markers, "show tabs, line endings, carriage returns, and EOF markers")
 	fs.BoolVar(&opts.liveLinks, "live-links", opts.liveLinks, "enable live OSC 8 hyperlinks in the program")
 	fs.BoolVar(&opts.mouseCapture, "mouse", opts.mouseCapture, "capture mouse button and wheel events in the program")
 	fs.BoolVar(&opts.quitAtEOF, "quit-at-eof", opts.quitAtEOF, "long form of -e")
 	fs.BoolVar(&opts.quitAtEOFFirst, "QUIT-AT-EOF", opts.quitAtEOFFirst, "long form of -E")
+	fs.BoolVar(&opts.literal, "literal", opts.literal, "show escape sequences literally instead of interpreting them")
 	fs.BoolVar(&opts.secure, "secure", opts.secure, "disable standalone commands that launch external programs")
 	fs.BoolVar(&opts.squeeze, "s", opts.squeeze, "collapse repeated blank lines in the current view")
 	fs.BoolVar(&opts.squeeze, "squeeze", opts.squeeze, "collapse repeated blank lines in the current view")
 	fs.StringVar(&opts.configPath, "config", opts.configPath, "path to a JSON config file")
 	fs.StringVar(&opts.presetName, "theme", opts.presetName, "visual theme: dark, light, plain, pretty")
 	fs.StringVar(&opts.chromeName, "chrome", opts.chromeName, "chrome override: auto, none, single, rounded")
-	fs.StringVar(&opts.renderName, "render", opts.renderName, "render mode: hybrid, literal, presentation")
 	fs.StringVar(&opts.title, "title", opts.title, "frame title")
 	fs.IntVar(&opts.tabWidth, "x", opts.tabWidth, "tab width")
 	fs.BoolVar(&opts.version, "version", opts.version, "display program version and exit")
 
 	var ignoreSmartCase bool
 	var ignoreCase bool
+	var noMarkers bool
+	var noLiteral bool
 	var noMouse bool
 	fs.BoolVar(&ignoreSmartCase, "i", false, "smart-case search")
 	fs.BoolVar(&ignoreCase, "I", false, "case-insensitive search")
+	fs.BoolVar(&noMarkers, "no-markers", false, "hide tabs, line endings, carriage returns, and EOF markers")
+	fs.BoolVar(&noLiteral, "no-literal", false, "interpret supported escapes as styles instead of showing them literally")
 	fs.BoolVar(&noMouse, "no-mouse", false, "disable mouse capture in the program")
 
 	if err := fs.Parse(args); err != nil {
@@ -551,6 +554,12 @@ func parseProgramFlags(args []string) (programOptions, []string, error) {
 	}
 	if noMouse {
 		opts.mouseCapture = false
+	}
+	if noMarkers {
+		opts.markers = false
+	}
+	if noLiteral {
+		opts.literal = false
 	}
 	if opts.showHelp {
 		return opts, nil, nil
@@ -621,7 +630,10 @@ func programFlagHelps() []programFlagHelp {
 		{names: []string{"-N"}, description: "Show line numbers."},
 		{names: []string{"-R"}, description: "Accepted as a less-compatibility no-op."},
 		{names: []string{"-S"}, description: "Accepted as a less-compatibility no-op."},
-		{names: []string{"--hidden"}, description: "Show tabs, line endings, carriage returns, and EOF markers."},
+		{names: []string{"--markers"}, description: "Show tabs, line endings, carriage returns, and EOF markers."},
+		{names: []string{"--no-markers"}, description: "Hide tabs, line endings, carriage returns, and EOF markers."},
+		{names: []string{"--literal"}, description: "Show escape sequences literally instead of interpreting them."},
+		{names: []string{"--no-literal"}, description: "Interpret supported escapes as styles instead of showing them literally."},
 		{names: []string{"--live-links"}, description: "Enable live OSC 8 hyperlinks in the standalone program."},
 		{names: []string{"--mouse"}, description: "Capture mouse button and wheel events in the standalone program."},
 		{names: []string{"--no-mouse"}, description: "Disable mouse button and wheel capture in the standalone program."},
@@ -630,7 +642,6 @@ func programFlagHelps() []programFlagHelp {
 		{names: []string{"--config"}, value: "<path>", description: "Load a JSON config file; overrides GOLESS_CONFIG and the default per-user path."},
 		{names: []string{"--theme"}, value: "<dark|light|plain|pretty>", description: "Select the visual theme."},
 		{names: []string{"--chrome"}, value: "<auto|none|single|rounded>", description: "Override the pager frame style."},
-		{names: []string{"--render"}, value: "<hybrid|literal|presentation>", description: "Choose how escape sequences are rendered."},
 		{names: []string{"--title"}, value: "<text>", description: "Set the frame title."},
 		{names: []string{"-x"}, value: "<n>", description: "Set the tab width."},
 		{names: []string{"-i"}, description: "Use smart-case search."},
@@ -731,7 +742,10 @@ func programSuggestFlag(name string) string {
 		"--version",
 		"--quit-at-eof",
 		"--QUIT-AT-EOF",
-		"--hidden",
+		"--markers",
+		"--no-markers",
+		"--literal",
+		"--no-literal",
 		"--live-links",
 		"--mouse",
 		"--no-mouse",
@@ -740,7 +754,6 @@ func programSuggestFlag(name string) string {
 		"--config",
 		"--theme",
 		"--chrome",
-		"--render",
 		"--title",
 	}
 
@@ -2125,7 +2138,7 @@ func newProgramPager(
 	renderMode goless.RenderMode,
 	preset goless.Preset,
 	chrome goless.Chrome,
-	hidden bool,
+	markers bool,
 	liveLinks bool,
 	lineNumbers bool,
 	searchCaseMode goless.SearchCaseMode,
@@ -2142,7 +2155,7 @@ func newProgramPager(
 		goless.WithSqueezeBlankLines(squeeze),
 		goless.WithText(programText()),
 		goless.WithTheme(preset.Theme),
-		goless.WithVisualization(programVisualization(hidden)),
+		goless.WithVisualization(programVisualization(markers)),
 		goless.WithHyperlinkHandler(programHyperlinkHandler(liveLinks)),
 		goless.WithCommandHandler(commandHandler),
 		goless.WithChrome(chrome),
@@ -2189,17 +2202,4 @@ func programChrome(name, title string, base goless.Chrome) (goless.Chrome, error
 		BottomRight: frame.BottomRight,
 	}
 	return chrome, nil
-}
-
-func programRenderMode(name string) (goless.RenderMode, error) {
-	switch name {
-	case "literal":
-		return goless.RenderLiteral, nil
-	case "presentation":
-		return goless.RenderPresentation, nil
-	case "hybrid", "":
-		return goless.RenderHybrid, nil
-	default:
-		return goless.RenderHybrid, fmt.Errorf("unknown render mode %q; expected hybrid, literal, or presentation", name)
-	}
 }

--- a/cmd/goless/main_test.go
+++ b/cmd/goless/main_test.go
@@ -252,33 +252,22 @@ func TestProgramPresetDefaultPretty(t *testing.T) {
 	}
 }
 
-func TestProgramRenderMode(t *testing.T) {
-	tests := []struct {
-		name    string
-		want    goless.RenderMode
-		wantErr bool
-	}{
-		{name: "literal", want: goless.RenderLiteral},
-		{name: "presentation", want: goless.RenderPresentation},
-		{name: "hybrid", want: goless.RenderHybrid},
-		{name: "", want: goless.RenderHybrid},
-		{name: "bogus", want: goless.RenderHybrid, wantErr: true},
+func TestParseProgramFlagsMarkersAndLiteral(t *testing.T) {
+	opts, args, err := parseProgramFlags([]string{"--markers", "--literal", "sample.txt"})
+	if err != nil {
+		t.Fatalf("parseProgramFlags(...) failed: %v", err)
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := programRenderMode(tt.name)
-			if tt.wantErr {
-				if err == nil {
-					t.Fatalf("programRenderMode(%q) = nil error, want error", tt.name)
-				}
-			} else if err != nil {
-				t.Fatalf("programRenderMode(%q) failed: %v", tt.name, err)
-			}
-			if got != tt.want {
-				t.Fatalf("programRenderMode(%q) = %v, want %v", tt.name, got, tt.want)
-			}
-		})
+	if !opts.markers {
+		t.Fatal("parseProgramFlags(...) did not enable markers")
+	}
+	if !opts.literal {
+		t.Fatal("parseProgramFlags(...) did not enable literal mode")
+	}
+	if got, want := len(args), 1; got != want {
+		t.Fatalf("len(args) = %d, want %d", got, want)
+	}
+	if got, want := args[0], "sample.txt"; got != want {
+		t.Fatalf("args[0] = %q, want %q", got, want)
 	}
 }
 
@@ -1109,6 +1098,21 @@ func TestRunUnknownFlagWritesToStderr(t *testing.T) {
 	}
 }
 
+func TestRunRejectsLegacyHiddenAndRenderFlags(t *testing.T) {
+	for _, flagName := range []string{"--hidden", "--render"} {
+		t.Run(flagName, func(t *testing.T) {
+			_, err := runProgramForTest(t, []string{flagName}, "")
+			if err == nil {
+				t.Fatalf("run(%s) = nil error, want unknown option error", flagName)
+			}
+			want := strings.TrimPrefix(flagName, "--")
+			if got := err.Error(); !strings.Contains(got, "flag provided but not defined: -"+want) {
+				t.Fatalf("run(%s) error = %q, want unknown option detail", flagName, got)
+			}
+		})
+	}
+}
+
 func TestParseProgramFlagsLicense(t *testing.T) {
 	opts, args, err := parseProgramFlags([]string{"--license"})
 	if err != nil {
@@ -1139,16 +1143,6 @@ func TestRunPassesThroughStdinToPipe(t *testing.T) {
 	}
 	if got, want := output, "alpha\nbeta\n"; got != want {
 		t.Fatalf("run(stdin passthrough) output = %q, want %q", got, want)
-	}
-}
-
-func TestRunRejectsUnknownRenderMode(t *testing.T) {
-	_, err := runProgramForTest(t, []string{"--render", "bogus"}, "")
-	if err == nil {
-		t.Fatal("run(--render bogus) = nil error, want error")
-	}
-	if got := err.Error(); !strings.Contains(got, "unknown render mode") {
-		t.Fatalf("run(--render bogus) error = %q, want unknown render mode", got)
 	}
 }
 

--- a/internal/defaults/help.txt
+++ b/internal/defaults/help.txt
@@ -29,7 +29,7 @@
   /                   search forward
   ?                   search backward
   n N                 next/previous match
-  F2                  cycle case mode (smart/case/nocase)
+  F2                  cycle case mode (auto/case/nocase)
   F3                  cycle match mode (substring/word/regex)
 
 [1;4mPrompt Editing[0m
@@ -47,13 +47,16 @@
 [1;4mCommands[0m
   :123                    jump to line 123
   :50%                    jump to 50%
-  :set number             show line numbers
-  :set wrap               soft-wrap long lines
-  :set list               show hidden-character markers
-  :set squeeze            collapse adjacent blank lines
-  :set tabstop=[3mnum[0m        set tab width
-  :set pinlines=[3mnum[0m       pin top lines
-  :set pincols=[3mnum[0m        pin left columns
-  :set ignorecase         search without case sensitivity
-  :set smartcase          search smart-case
-  :set searchmode=[3mmode[0m    set match mode (sub|word|regex)
+  :number                 show line numbers
+  :nonumber               hide line numbers
+  :wrap                   soft-wrap long lines
+  :nowrap                 disable soft wrapping
+  :markers                show hidden-character markers
+  :nomarkers              hide hidden-character markers
+  :squeeze                collapse adjacent blank lines
+  :nosqueeze              keep blank lines
+  :tabs [3mnum[0m              set tab width
+  :pin [rows=[3mnum[0m] [cols=[3mnum[0m]  pin top rows and/or left columns
+  :match [auto|nocase|case] [sub|word|regex]  control search case and matching
+  :help                   show the built-in help overlay
+  :reload                 reload current file/input

--- a/internal/view/search.go
+++ b/internal/view/search.go
@@ -562,7 +562,8 @@ func (v *Viewer) runCommand(text string) (commit bool, quit bool) {
 		return true, false
 	}
 
-	if v.runSetCommand(text) {
+	fields := strings.Fields(text)
+	if v.runDirectCommand(fields) {
 		return true, false
 	}
 
@@ -686,7 +687,15 @@ func parsePercentCommand(text string) (int, bool) {
 	return percent, true
 }
 
-func parseSetAssignment(text string) (name, value string, ok bool) {
+func setVisualizationEnabled(visual Visualization, enabled bool) Visualization {
+	visual.ShowTabs = enabled
+	visual.ShowNewlines = enabled
+	visual.ShowCarriageReturns = enabled
+	visual.ShowEOF = enabled
+	return visual
+}
+
+func parseCommandAssignment(text string) (name, value string, ok bool) {
 	index := strings.Index(text, "=")
 	if index < 0 {
 		return "", "", false
@@ -699,136 +708,197 @@ func parseSetAssignment(text string) (name, value string, ok bool) {
 	return name, value, true
 }
 
-func visualizationEnabled(visual Visualization) bool {
-	return visual.ShowTabs || visual.ShowNewlines || visual.ShowCarriageReturns || visual.ShowEOF
+func parseSearchCaseModeValue(value string) (SearchCaseMode, bool) {
+	switch value {
+	case "auto", "smart":
+		return SearchSmartCase, true
+	case "case", "sensitive":
+		return SearchCaseSensitive, true
+	case "nocase", "insensitive":
+		return SearchCaseInsensitive, true
+	default:
+		return 0, false
+	}
 }
 
-func setVisualizationEnabled(visual Visualization, enabled bool) Visualization {
-	visual.ShowTabs = enabled
-	visual.ShowNewlines = enabled
-	visual.ShowCarriageReturns = enabled
-	visual.ShowEOF = enabled
-	return visual
+func parseSearchModeValue(value string) (SearchMode, bool) {
+	switch value {
+	case "sub", "substring":
+		return SearchSubstring, true
+	case "word", "wholeword":
+		return SearchWholeWord, true
+	case "regex":
+		return SearchRegex, true
+	default:
+		return 0, false
+	}
 }
 
-func (v *Viewer) runSetCommand(text string) bool {
-	fields := strings.Fields(text)
-	if len(fields) == 0 || fields[0] != "set" {
+func (v *Viewer) runMatchCommand(args []string) bool {
+	if len(args) == 0 {
 		return false
 	}
 
-	setText := strings.TrimSpace(strings.TrimPrefix(text, "set"))
-	if setText == "" {
-		return false
-	}
+	caseMode := v.SearchCaseMode()
+	mode := v.SearchMode()
+	caseSet := false
+	modeSet := false
 
-	if name, value, ok := parseSetAssignment(setText); ok {
-		switch name {
-		case "searchcase":
-			var mode SearchCaseMode
-			switch value {
-			case "smart":
-				mode = SearchSmartCase
-			case "case", "sensitive":
-				mode = SearchCaseSensitive
-			case "nocase", "insensitive":
-				mode = SearchCaseInsensitive
-			default:
-				v.setTransientMessage(v.text.CommandUnknown(text))
-				return true
+	for _, arg := range args {
+		if name, value, ok := parseCommandAssignment(arg); ok {
+			switch name {
+			case "case":
+				parsed, ok := parseSearchCaseModeValue(value)
+				if !ok {
+					return false
+				}
+				caseMode = parsed
+				caseSet = true
+				continue
+			case "mode":
+				parsed, ok := parseSearchModeValue(value)
+				if !ok {
+					return false
+				}
+				mode = parsed
+				modeSet = true
+				continue
 			}
-			v.SetSearchCaseMode(mode)
-			v.setMessage("")
-			return true
-		case "searchmode":
-			var mode SearchMode
-			switch value {
-			case "sub", "substring":
-				mode = SearchSubstring
-			case "word", "wholeword":
-				mode = SearchWholeWord
-			case "regex":
-				mode = SearchRegex
-			default:
-				v.setTransientMessage(v.text.CommandUnknown(text))
-				return true
-			}
-			v.SetSearchMode(mode)
-			v.setMessage("")
-			return true
-		case "tabstop":
-			width, err := strconv.Atoi(value)
-			if err != nil || width <= 0 {
-				v.setTransientMessage(v.text.CommandUnknown(text))
-				return true
-			}
-			v.SetTabWidth(width)
-			v.setMessage("")
-			return true
-		case "pinlines":
-			count, err := strconv.Atoi(value)
-			if err != nil || count < 0 {
-				v.setTransientMessage(v.text.CommandUnknown(text))
-				return true
-			}
-			v.SetHeaderLines(count)
-			v.setMessage("")
-			return true
-		case "pincols":
-			count, err := strconv.Atoi(value)
-			if err != nil || count < 0 {
-				v.setTransientMessage(v.text.CommandUnknown(text))
-				return true
-			}
-			v.SetHeaderColumns(count)
-			v.setMessage("")
-			return true
-		default:
-			v.setTransientMessage(v.text.CommandUnknown(text))
-			return true
 		}
+		if !caseSet {
+			if parsed, ok := parseSearchCaseModeValue(arg); ok {
+				caseMode = parsed
+				caseSet = true
+				continue
+			}
+		}
+		if !modeSet {
+			if parsed, ok := parseSearchModeValue(arg); ok {
+				mode = parsed
+				modeSet = true
+				continue
+			}
+		}
+		return false
 	}
 
-	if len(fields) != 2 {
-		v.setTransientMessage(v.text.CommandUnknown(text))
+	v.SetSearchCaseMode(caseMode)
+	v.SetSearchMode(mode)
+	v.setMessage("")
+	return true
+}
+
+func (v *Viewer) runPinCommand(args []string) bool {
+	if len(args) == 0 {
 		return true
 	}
 
-	switch fields[1] {
+	lines := -1
+	columns := -1
+
+	for _, arg := range args {
+		name, value, ok := parseCommandAssignment(arg)
+		if !ok {
+			return false
+		}
+		count, err := strconv.Atoi(value)
+		if err != nil || count < 0 {
+			return false
+		}
+		switch name {
+		case "rows":
+			lines = count
+		case "cols":
+			columns = count
+		default:
+			return false
+		}
+	}
+
+	if lines < 0 && columns < 0 {
+		return false
+	}
+	if lines >= 0 {
+		v.SetHeaderLines(lines)
+	}
+	if columns >= 0 {
+		v.SetHeaderColumns(columns)
+	}
+	return true
+}
+
+func (v *Viewer) runDirectCommand(fields []string) bool {
+	if len(fields) == 0 {
+		return false
+	}
+
+	switch fields[0] {
 	case "number":
+		if len(fields) != 1 {
+			return false
+		}
 		v.SetLineNumbers(true)
 	case "nonumber":
+		if len(fields) != 1 {
+			return false
+		}
 		v.SetLineNumbers(false)
-	case "invnumber":
-		v.ToggleLineNumbers()
 	case "wrap":
+		if len(fields) != 1 {
+			return false
+		}
 		v.SetWrapMode(layout.SoftWrap)
 	case "nowrap":
+		if len(fields) != 1 {
+			return false
+		}
 		v.SetWrapMode(layout.NoWrap)
-	case "invwrap":
-		v.ToggleWrap()
-	case "list":
+	case "markers", "list":
+		if len(fields) != 1 {
+			return false
+		}
 		v.SetVisualization(setVisualizationEnabled(v.cfg.Visualization, true))
-	case "nolist":
+	case "nomarkers", "nolist":
+		if len(fields) != 1 {
+			return false
+		}
 		v.SetVisualization(setVisualizationEnabled(v.cfg.Visualization, false))
-	case "invlist":
-		v.SetVisualization(setVisualizationEnabled(v.cfg.Visualization, !visualizationEnabled(v.cfg.Visualization)))
 	case "squeeze":
+		if len(fields) != 1 {
+			return false
+		}
 		v.SetSqueezeBlankLines(true)
 	case "nosqueeze":
-		v.SetSqueezeBlankLines(false)
-	case "invsqueeze":
-		v.SetSqueezeBlankLines(!v.SqueezeBlankLines())
-	case "ignorecase":
-		v.SetSearchCaseMode(SearchCaseInsensitive)
-	case "noignorecase":
-		v.SetSearchCaseMode(SearchCaseSensitive)
-	case "smartcase":
-		v.SetSearchCaseMode(SearchSmartCase)
-	case "nosmartcase":
-		if v.SearchCaseMode() == SearchSmartCase {
-			v.SetSearchCaseMode(SearchCaseInsensitive)
+		if len(fields) != 1 {
+			return false
 		}
+		v.SetSqueezeBlankLines(false)
+	case "tabs":
+		if len(fields) != 2 {
+			return false
+		}
+		width, err := strconv.Atoi(fields[1])
+		if err != nil || width <= 0 {
+			return false
+		}
+		v.SetTabWidth(width)
+	case "pin":
+		if !v.runPinCommand(fields[1:]) {
+			return false
+		}
+	case "match", "search":
+		if len(fields) == 1 {
+			v.setTransientMessage("match requires a case or mode argument")
+			return true
+		}
+		if !v.runMatchCommand(fields[1:]) {
+			return false
+		}
+	case "help":
+		if len(fields) != 1 {
+			return false
+		}
+		v.ShowInformation(v.text.HelpTitle, v.text.HelpBody)
 	default:
 		return false
 	}

--- a/internal/view/search.go
+++ b/internal/view/search.go
@@ -886,7 +886,7 @@ func (v *Viewer) runDirectCommand(fields []string) bool {
 		if !v.runPinCommand(fields[1:]) {
 			return false
 		}
-	case "match", "search":
+	case "match":
 		if len(fields) == 1 {
 			v.setTransientMessage("match requires a case or mode argument")
 			return true

--- a/internal/view/search.go
+++ b/internal/view/search.go
@@ -784,7 +784,6 @@ func (v *Viewer) runMatchCommand(args []string) bool {
 
 	v.SetSearchCaseMode(caseMode)
 	v.SetSearchMode(mode)
-	v.setMessage("")
 	return true
 }
 
@@ -832,6 +831,7 @@ func (v *Viewer) runDirectCommand(fields []string) bool {
 		return false
 	}
 
+	preserveMessage := false
 	switch fields[0] {
 	case "number":
 		if len(fields) != 1 {
@@ -891,9 +891,11 @@ func (v *Viewer) runDirectCommand(fields []string) bool {
 			v.setTransientMessage("match requires a case or mode argument")
 			return true
 		}
+		prevMessage := v.message
 		if !v.runMatchCommand(fields[1:]) {
 			return false
 		}
+		preserveMessage = v.message != prevMessage
 	case "help":
 		if len(fields) != 1 {
 			return false
@@ -903,7 +905,9 @@ func (v *Viewer) runDirectCommand(fields []string) bool {
 		return false
 	}
 
-	v.setMessage("")
+	if !preserveMessage {
+		v.setMessage("")
+	}
 	return true
 }
 

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -734,7 +734,7 @@ func runViewerCommand(v *Viewer, command string) {
 	v.HandleKey(keyKey(tcell.KeyEnter))
 }
 
-func TestSetNumbersCommand(t *testing.T) {
+func TestNumberCommands(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\ntwo\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -743,16 +743,16 @@ func TestSetNumbersCommand(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 4)
 
-	for _, command := range []string{"set number", "set invnumber"} {
+	for _, command := range []string{"number", "nonumber"} {
 		runViewerCommand(v, command)
 	}
 
 	if got, want := v.LineNumbers(), false; got != want {
-		t.Fatalf("LineNumbers after :set number + :set invnumber = %v, want %v", got, want)
+		t.Fatalf("LineNumbers after number + nonumber = %v, want %v", got, want)
 	}
 }
 
-func TestSetPinLinesCommand(t *testing.T) {
+func TestPinRowsCommand(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\ntwo\nthree\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -761,14 +761,14 @@ func TestSetPinLinesCommand(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 4)
 
-	runViewerCommand(v, "set pinlines=1")
+	runViewerCommand(v, "pin rows=1")
 
 	if got, want := v.HeaderLines(), 1; got != want {
-		t.Fatalf("HeaderLines after :set pinlines=1 = %d, want %d", got, want)
+		t.Fatalf("HeaderLines after pin rows=1 = %d, want %d", got, want)
 	}
 }
 
-func TestSetPinLinesCommandClearsPriorInvalidMessage(t *testing.T) {
+func TestPinRowsCommandClearsPriorInvalidMessage(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\ntwo\nthree\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -777,22 +777,22 @@ func TestSetPinLinesCommandClearsPriorInvalidMessage(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 4)
 
-	runViewerCommand(v, "set pinline=1")
-	if !strings.Contains(v.message, "set pinline=1") {
+	runViewerCommand(v, "pin rows=1 extra")
+	if !strings.Contains(v.message, "pin rows=1 extra") {
 		t.Fatalf("message after invalid command = %q, want it to mention invalid command", v.message)
 	}
 
-	runViewerCommand(v, "set pinlines=1")
+	runViewerCommand(v, "pin rows=1")
 
 	if got, want := v.HeaderLines(), 1; got != want {
-		t.Fatalf("HeaderLines after :set pinlines=1 = %d, want %d", got, want)
+		t.Fatalf("HeaderLines after pin rows=1 = %d, want %d", got, want)
 	}
 	if v.message != "" {
 		t.Fatalf("message after valid command = %q, want empty", v.message)
 	}
 }
 
-func TestSetSqueezeCommand(t *testing.T) {
+func TestSqueezeCommands(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\n\n\nthree\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -801,16 +801,16 @@ func TestSetSqueezeCommand(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 4)
 
-	for _, command := range []string{"set squeeze", "set invsqueeze"} {
+	for _, command := range []string{"squeeze", "nosqueeze"} {
 		runViewerCommand(v, command)
 	}
 
 	if got, want := v.SqueezeBlankLines(), false; got != want {
-		t.Fatalf("SqueezeBlankLines after :set squeeze + :set invsqueeze = %v, want %v", got, want)
+		t.Fatalf("SqueezeBlankLines after squeeze + nosqueeze = %v, want %v", got, want)
 	}
 }
 
-func TestSetPinColumnsCommand(t *testing.T) {
+func TestPinColumnsCommand(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\ntwo\nthree\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -819,14 +819,33 @@ func TestSetPinColumnsCommand(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 4)
 
-	runViewerCommand(v, "set pincols=2")
+	runViewerCommand(v, "pin cols=2")
 
 	if got, want := v.HeaderColumns(), 2; got != want {
-		t.Fatalf("HeaderColumns after :set pincols=2 = %d, want %d", got, want)
+		t.Fatalf("HeaderColumns after pin cols=2 = %d, want %d", got, want)
 	}
 }
 
-func TestSetDisplayCommands(t *testing.T) {
+func TestPinRowsAndColumnsCommand(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("one\ntwo\nthree\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 4)
+
+	runViewerCommand(v, "pin rows=1 cols=2")
+
+	if got, want := v.HeaderLines(), 1; got != want {
+		t.Fatalf("HeaderLines after pin rows=1 cols=2 = %d, want %d", got, want)
+	}
+	if got, want := v.HeaderColumns(), 2; got != want {
+		t.Fatalf("HeaderColumns after pin rows=1 cols=2 = %d, want %d", got, want)
+	}
+}
+
+func TestDisplayCommands(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\ttwo\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -835,25 +854,25 @@ func TestSetDisplayCommands(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 4)
 
-	for _, command := range []string{"set wrap", "set list", "set tabstop=2"} {
+	for _, command := range []string{"wrap", "markers", "tabs 2"} {
 		runViewerCommand(v, command)
 	}
 
 	if got, want := v.WrapMode(), layout.SoftWrap; got != want {
-		t.Fatalf("WrapMode after :set wrap = %v, want %v", got, want)
+		t.Fatalf("WrapMode after wrap = %v, want %v", got, want)
 	}
 	if got, want := v.cfg.Visualization.ShowTabs, true; got != want {
-		t.Fatalf("Visualization.ShowTabs after :set list = %v, want %v", got, want)
+		t.Fatalf("Visualization.ShowTabs after markers = %v, want %v", got, want)
 	}
 	if got, want := v.cfg.Visualization.ShowNewlines, true; got != want {
-		t.Fatalf("Visualization.ShowNewlines after :set list = %v, want %v", got, want)
+		t.Fatalf("Visualization.ShowNewlines after markers = %v, want %v", got, want)
 	}
 	if got, want := v.cfg.TabWidth, 2; got != want {
-		t.Fatalf("TabWidth after :set tabstop=2 = %d, want %d", got, want)
+		t.Fatalf("TabWidth after tabs 2 = %d, want %d", got, want)
 	}
 }
 
-func TestSetDisplayToggleCommands(t *testing.T) {
+func TestDisplayReverseCommands(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\ttwo\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -862,27 +881,20 @@ func TestSetDisplayToggleCommands(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 4)
 
-	runViewerCommand(v, "set invwrap")
-	if got, want := v.WrapMode(), layout.SoftWrap; got != want {
-		t.Fatalf("WrapMode after first :set invwrap = %v, want %v", got, want)
-	}
-	runViewerCommand(v, "set invwrap")
+	runViewerCommand(v, "wrap")
+	runViewerCommand(v, "nowrap")
 	if got, want := v.WrapMode(), layout.NoWrap; got != want {
-		t.Fatalf("WrapMode after second :set invwrap = %v, want %v", got, want)
+		t.Fatalf("WrapMode after wrap + nowrap = %v, want %v", got, want)
 	}
 
-	runViewerCommand(v, "set list")
-	runViewerCommand(v, "set nolist")
+	runViewerCommand(v, "markers")
+	runViewerCommand(v, "nomarkers")
 	if got, want := v.cfg.Visualization.ShowTabs, false; got != want {
-		t.Fatalf("Visualization.ShowTabs after :set nolist = %v, want %v", got, want)
-	}
-	runViewerCommand(v, "set invlist")
-	if got, want := v.cfg.Visualization.ShowTabs, true; got != want {
-		t.Fatalf("Visualization.ShowTabs after :set invlist = %v, want %v", got, want)
+		t.Fatalf("Visualization.ShowTabs after markers + nomarkers = %v, want %v", got, want)
 	}
 }
 
-func TestSetInvalidCommandsLeaveStateUnchanged(t *testing.T) {
+func TestInvalidCommandsLeaveStateUnchanged(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("one\ttwo\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -891,20 +903,64 @@ func TestSetInvalidCommandsLeaveStateUnchanged(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 4)
 
-	runViewerCommand(v, "set tabstop=0")
+	runViewerCommand(v, "tabs 0")
 	if got, want := v.cfg.TabWidth, 4; got != want {
-		t.Fatalf("TabWidth after invalid :set tabstop=0 = %d, want %d", got, want)
+		t.Fatalf("TabWidth after invalid tabs 0 = %d, want %d", got, want)
 	}
-	if !strings.Contains(v.message, "set tabstop=0") {
-		t.Fatalf("message after invalid tabstop = %q, want invalid command text", v.message)
+	if !strings.Contains(v.message, "tabs 0") {
+		t.Fatalf("message after invalid tabs command = %q, want invalid command text", v.message)
 	}
 
-	runViewerCommand(v, "set pinlines=1 extra")
+	runViewerCommand(v, "pin rows=1 extra")
 	if got, want := v.HeaderLines(), 0; got != want {
 		t.Fatalf("HeaderLines after malformed assignment = %d, want %d", got, want)
 	}
-	if !strings.Contains(v.message, "set pinlines=1 extra") {
+	if !strings.Contains(v.message, "pin rows=1 extra") {
 		t.Fatalf("message after malformed assignment = %q, want invalid command text", v.message)
+	}
+}
+
+func TestHelpCommandShowsHelpOverlay(t *testing.T) {
+	doc := model.NewDocument(4)
+	v := New(doc, Config{
+		TabWidth:   4,
+		WrapMode:   layout.NoWrap,
+		ShowStatus: true,
+		Text: Text{
+			HelpTitle: "Ayuda",
+			HelpBody:  "contenido",
+		},
+	})
+
+	runViewerCommand(v, "help")
+
+	if got, want := v.mode, modeHelp; got != want {
+		t.Fatalf("mode after help = %v, want %v", got, want)
+	}
+	if got, want := v.informationTitle(), "Ayuda"; got != want {
+		t.Fatalf("help title after help = %q, want %q", got, want)
+	}
+	if got, want := v.informationBody(), "contenido"; got != want {
+		t.Fatalf("help body after help = %q, want %q", got, want)
+	}
+}
+
+func TestMatchCommandWithoutArgumentsShowsHelpfulMessage(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alpha\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	runViewerCommand(v, "match")
+
+	if got, want := v.message, "match requires a case or mode argument"; got != want {
+		t.Fatalf("message after bare match = %q, want %q", got, want)
+	}
+	if got, want := v.mode, modeNormal; got != want {
+		t.Fatalf("mode after bare match = %v, want %v", got, want)
 	}
 }
 
@@ -1674,7 +1730,7 @@ func TestPromptHistoryDownRestoresDraft(t *testing.T) {
 	}
 }
 
-func TestSetSearchCaseCommand(t *testing.T) {
+func TestSearchCaseCommands(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("Alpha\nbeta\nALPHA\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -1684,38 +1740,19 @@ func TestSetSearchCaseCommand(t *testing.T) {
 	v.SetSize(20, 2)
 
 	for _, command := range []string{
-		"set ignorecase",
-		"set noignorecase",
-		"set smartcase",
-		"set nosmartcase",
-		"set searchcase=smart",
+		"match nocase",
+		"match case",
+		"match auto",
 	} {
 		runViewerCommand(v, command)
 	}
 
 	if got, want := v.SearchCaseMode(), SearchSmartCase; got != want {
-		t.Fatalf("SearchCaseMode after :set commands = %v, want %v", got, want)
+		t.Fatalf("SearchCaseMode after case commands = %v, want %v", got, want)
 	}
 }
 
-func TestSetNoSmartCasePreservesCaseSensitiveMode(t *testing.T) {
-	doc := model.NewDocument(4)
-	if err := doc.Append([]byte("Alpha\nbeta\nALPHA\n")); err != nil {
-		t.Fatalf("Append failed: %v", err)
-	}
-
-	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
-	v.SetSize(20, 2)
-
-	runViewerCommand(v, "set noignorecase")
-	runViewerCommand(v, "set nosmartcase")
-
-	if got, want := v.SearchCaseMode(), SearchCaseSensitive; got != want {
-		t.Fatalf("SearchCaseMode after :set noignorecase + :set nosmartcase = %v, want %v", got, want)
-	}
-}
-
-func TestSetSearchModeCommand(t *testing.T) {
+func TestSearchModeCommands(t *testing.T) {
 	doc := model.NewDocument(4)
 	if err := doc.Append([]byte("alphabet alpha\n")); err != nil {
 		t.Fatalf("Append failed: %v", err)
@@ -1724,12 +1761,101 @@ func TestSetSearchModeCommand(t *testing.T) {
 	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
 	v.SetSize(20, 2)
 
-	for _, command := range []string{"set searchmode=word", "set searchmode=regex", "set searchmode=sub"} {
+	for _, command := range []string{"match word", "match regex", "match sub"} {
 		runViewerCommand(v, command)
 	}
 
 	if got, want := v.SearchMode(), SearchSubstring; got != want {
-		t.Fatalf("SearchMode after :set commands = %v, want %v", got, want)
+		t.Fatalf("SearchMode after search mode commands = %v, want %v", got, want)
+	}
+}
+
+func TestSearchCommandSetsMultipleOptions(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alphabet alpha\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	runViewerCommand(v, "match nocase regex")
+
+	if got, want := v.SearchCaseMode(), SearchCaseInsensitive; got != want {
+		t.Fatalf("SearchCaseMode after search command = %v, want %v", got, want)
+	}
+	if got, want := v.SearchMode(), SearchRegex; got != want {
+		t.Fatalf("SearchMode after search command = %v, want %v", got, want)
+	}
+}
+
+func TestSearchCommandRejectsInvalidAssignments(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alphabet alpha\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	runViewerCommand(v, "match maybe")
+	if got, want := v.SearchCaseMode(), SearchSmartCase; got != want {
+		t.Fatalf("SearchCaseMode after invalid search command = %v, want %v", got, want)
+	}
+}
+
+func TestSearchModeCommandRejectsInvalidAssignments(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alphabet alpha\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	runViewerCommand(v, "mode invalid")
+	if got, want := v.SearchMode(), SearchSubstring; got != want {
+		t.Fatalf("SearchMode after invalid mode command = %v, want %v", got, want)
+	}
+}
+
+func TestSearchCommandCanSetSearchMode(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alphabet alpha\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	for _, command := range []string{"match word", "match regex", "match sub"} {
+		runViewerCommand(v, command)
+	}
+
+	if got, want := v.SearchMode(), SearchSubstring; got != want {
+		t.Fatalf("SearchMode after search commands = %v, want %v", got, want)
+	}
+}
+
+func TestPinEmptyCommandIsNoop(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("one\ntwo\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 4)
+
+	runViewerCommand(v, "pin")
+
+	if got, want := v.HeaderLines(), 0; got != want {
+		t.Fatalf("HeaderLines after empty pin = %d, want %d", got, want)
+	}
+	if got, want := v.HeaderColumns(), 0; got != want {
+		t.Fatalf("HeaderColumns after empty pin = %d, want %d", got, want)
+	}
+	if v.message != "" {
+		t.Fatalf("message after empty pin = %q, want empty", v.message)
 	}
 }
 

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -1021,6 +1021,32 @@ func TestMatchCommandInvalidAssignmentFallsThrough(t *testing.T) {
 	}
 }
 
+func TestMatchCommandPreservesRegexDiagnostics(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alpha[\nbeta\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	if !v.SearchForward("[") {
+		t.Fatal("SearchForward([) = false, want true in literal mode")
+	}
+	if v.message == "" {
+		t.Fatal("search message = empty, want literal search status")
+	}
+
+	runViewerCommand(v, "match regex")
+
+	if got, want := v.SearchMode(), SearchRegex; got != want {
+		t.Fatalf("SearchMode after match regex = %v, want %v", got, want)
+	}
+	if got := v.message; !strings.Contains(got, "regex:error") {
+		t.Fatalf("message after match regex = %q, want regex diagnostic", got)
+	}
+}
+
 func TestKeyBindingMatchesRequireExactNoModifierByDefault(t *testing.T) {
 	binding := keyBinding{
 		key:    tcell.KeyRune,

--- a/internal/view/viewer_test.go
+++ b/internal/view/viewer_test.go
@@ -964,6 +964,63 @@ func TestMatchCommandWithoutArgumentsShowsHelpfulMessage(t *testing.T) {
 	}
 }
 
+func TestSearchCommandIsRejected(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("alpha\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	runViewerCommand(v, "search")
+
+	if got, want := v.message, "unknown command: search"; got != want {
+		t.Fatalf("message after search = %q, want %q", got, want)
+	}
+	if got, want := v.mode, modeNormal; got != want {
+		t.Fatalf("mode after search = %v, want %v", got, want)
+	}
+}
+
+func TestMatchCommandAssignmentSyntax(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("Alpha\nalpha\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	runViewerCommand(v, "match case=nocase mode=regex")
+
+	if got, want := v.SearchCaseMode(), SearchCaseInsensitive; got != want {
+		t.Fatalf("SearchCaseMode after assignment syntax = %v, want %v", got, want)
+	}
+	if got, want := v.SearchMode(), SearchRegex; got != want {
+		t.Fatalf("SearchMode after assignment syntax = %v, want %v", got, want)
+	}
+}
+
+func TestMatchCommandInvalidAssignmentFallsThrough(t *testing.T) {
+	doc := model.NewDocument(4)
+	if err := doc.Append([]byte("Alpha\nalpha\n")); err != nil {
+		t.Fatalf("Append failed: %v", err)
+	}
+
+	v := New(doc, Config{TabWidth: 4, WrapMode: layout.NoWrap, ShowStatus: true})
+	v.SetSize(20, 2)
+
+	runViewerCommand(v, "match case=maybe")
+
+	if got, want := v.message, "unknown command: match case=maybe"; got != want {
+		t.Fatalf("message after invalid match assignment = %q, want %q", got, want)
+	}
+	if got, want := v.SearchCaseMode(), SearchSmartCase; got != want {
+		t.Fatalf("SearchCaseMode after invalid match assignment = %v, want %v", got, want)
+	}
+}
+
 func TestKeyBindingMatchesRequireExactNoModifierByDefault(t *testing.T) {
 	binding := keyBinding{
 		key:    tcell.KeyRune,


### PR DESCRIPTION
This is a substantial rethink of the command names and switches to the main program, that should make this easier for end-users. The "render" style is gone, replaced with literal no/literal, and the hidden whitespace markers are controlled via "markers".

The "set" commands have morphed into their own top-level commands for things like "wrap" and "nowrap", and the new "match" and "pin" commands.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added direct pager commands (:number/:nonumber, :wrap/:nowrap, :markers/:nomarkers, :squeeze/:nosqueeze, :tabs, :pin, :match) and a :help overlay.
  * Introduced CLI flags --markers/--no-markers and --literal/--no-literal; legacy --hidden/--render removed.
  * Visualization toggle (F5) now switches marker display.

* **Documentation**
  * Help and README updated for new commands and F2 search-case cycle (auto → case → nocase).
  * JSON config still accepts "hidden" while CLI exposes --markers/--no-markers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->